### PR TITLE
feat(domain): add Log domain model and LogRepository interface

### DIFF
--- a/internal/domain/model/log.go
+++ b/internal/domain/model/log.go
@@ -1,0 +1,16 @@
+package model
+
+import (
+	"time"
+)
+
+// Log はログエントリを表すドメインモデル
+type Log struct {
+	ID        string            // UUID
+	TraceID   string            // 分散トレーシング用の一意なID
+	Timestamp time.Time         // ログ発生時刻
+	Level     string            // ログレベル (INFO, WARN, ERROR)
+	Service   string            // 送信元サービス
+	Message   string            // ログメッセージ
+	Metadata  map[string]string // 追加情報（IP, リクエスト ID など）
+}

--- a/internal/domain/repository/log_repository.go
+++ b/internal/domain/repository/log_repository.go
@@ -1,0 +1,13 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/domain/model"
+)
+
+// LogRepository はログデータの永続化を担当
+type LogRepository interface {
+	SendLog(ctx context.Context, log *model.Log) error
+	GetLogs(ctx context.Context, service string, level string, limit int, offset int) ([]model.Log, error)
+}


### PR DESCRIPTION
## 概要

ログ収集システムにおけるドメイン層（ビジネスロジックのコア）を定義しました。  
本実装は、以下のリポジトリで定義されている gRPC の `logs.v1.Log` メッセージ仕様に準拠しています：

👉 [logs-collector-protos](https://github.com/KeitaShimura/logs-collector-protos)

## 変更内容

- `model.Log` を定義し、gRPC の `Log` メッセージと対応するフィールド（id, trace_id, timestamp, level, service, message, metadata）を実装
- ドメイン層でログの保存・取得処理を抽象化するために、`repository.LogRepository` インターフェースを定義
  - `SendLog`: ログの登録用
  - `GetLogs`: サービス名・ログレベルによるフィルタとページネーションによる取得用

## 実装方針

- proto定義との整合性を保ちつつ、アプリケーション層やインフラ層に依存しない形で構造体とインターフェースを設計
- 将来的に `start_time` や `trace_id` などの追加条件にも対応可能なよう、必要であれば `GetLogsRequest` の導入を検討

## 今後の予定

- ユースケース層でのログ送信・取得ロジックの実装
- インフラ層での `LogRepository` の実体実装（PostgreSQL, Elasticsearch など）
- gRPC層との変換ロジックの実装（proto ↔ domain）

## 補足

- 今回はドメイン層の定義のみを対象としており、実装（DB操作など）は含まれていません。
- gRPC の構造変更があった場合は、それに合わせて `model.Log` を調整予定です。