### PR TITLE
chore(makefile): update test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,15 +36,18 @@ build:
 run:
 	go run ${CMD_PACKAGES}
 
-# テスト実行（詳細出力付き）
-test:
-	go test -v ${ALL_PACKAGES}
+# 簡易テスト（レース検出・カバレッジなし、詳細出力あり）
+test-fast:
+	go test -v $(ALL_PACKAGES)
 
-# カバレッジ付きテストの実行とHTMLレポート出力
+# テスト実行（詳細出力 + カバレッジ + レース検出）
+test:
+	go test -v -race -cover $(ALL_PACKAGES)
+
+# カバレッジ付きテストの実行
 cover:
 	mkdir -p coverage
-	go test -cover ${ALL_PACKAGES} -coverprofile=coverage/cover.out
-	go tool cover -html=coverage/cover.out -o coverage/cover.html
+	go test -cover $(ALL_PACKAGES) -coverprofile=coverage/cover.out
 
 # コード生成（SQLBoilerによるDBモデル生成）
 generate:


### PR DESCRIPTION
## 概要

Makefile のテストターゲット構成を見直し、`test` / `test-fast` の役割を明確化しました。

## 変更内容

- 既存の簡易テスト（`go test -v ${ALL_PACKAGES}`）を `test-fast` に移行し、名称と役割を整理
- `test` ターゲットを `go test -v -race -cover` に変更し、詳細出力・データレース検出・カバレッジ取得を含む厳密な実行に変更
- `cover` ターゲットから HTML 出力を削除し、`cover.out` のみ出力されるように簡素化

## 意図

- `test-fast`: ローカル開発時に高速にテストを回す用途として定義
- `test`: CI・PR 対応など、信頼性と網羅性を担保する目的で使用
- HTML カバレッジレポートは不要と判断し、cover.out のみ CI 連携用に出力