### PR TITLE
feat(queue): add LogMessage struct for NATS log publishing

### DIFF
--- a/internal/infra/queue/message.go
+++ b/internal/infra/queue/message.go
@@ -1,0 +1,12 @@
+package queue
+
+// LogMessage は送信するログメッセージ構造体
+type LogMessage struct {
+	ID        string            `json:"id"`
+	TraceID   string            `json:"traceId"`
+	Timestamp string            `json:"timestamp"`
+	Level     string            `json:"level"`
+	Service   string            `json:"service"`
+	Message   string            `json:"message"`
+	Metadata  map[string]string `json:"metadata"`
+}


### PR DESCRIPTION
## 🔧 概要

NATS などのメッセージキューで送受信するログデータを表す構造体 `LogMessage` を定義しました。

---

## 📁 追加内容

- `internal/infra/queue/message.go` に `LogMessage` 構造体を追加
  - JSONマーシャリング対応
  - 今後 `producer.go` や `consumer.go` から使用されることを想定

---

## 🎯 目的

- 外部送信用DTOとしてのログ構造体を事前に定義
- ドメインモデル（`model.Log`）と分離し、責務を明確化

---

## ✅ 今後の展開

- この構造体を使って、ログ送信用の NATS Producer 実装を予定
- 必要に応じて `model.Log` → `LogMessage` の変換ロジックを追加予定