### PR TITLE
feat(queue): add Producer for publishing logs to NATS

### DIFF
--- a/internal/app/usecase/log_usecase_test.go
+++ b/internal/app/usecase/log_usecase_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
 )
 
+// 共通エラー定義
 var (
 	errMockDB              = errors.New("db error")
 	errMockLogsNil         = errors.New("mock GetLogs returned nil logs")

--- a/internal/infra/db/log_repository_test.go
+++ b/internal/infra/db/log_repository_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
 )
 
+// 共通エラー定義
 var (
 	errInsert = errors.New("insert error")
 	errQuery  = errors.New("db failure")

--- a/internal/infra/queue/producer.go
+++ b/internal/infra/queue/producer.go
@@ -1,0 +1,49 @@
+package queue
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+)
+
+// NATSConn は NATS 接続インターフェース（テストのために抽象化）
+type NATSConn interface {
+	Publish(subject string, data []byte) error
+}
+
+// Producer はログを NATS に送信する構造体
+type Producer struct {
+	Conn   NATSConn
+	Logger logger.Logger
+}
+
+// NewProducer は NATS に接続して Producer を作成
+func NewProducer(url string, logger logger.Logger) (*Producer, error) {
+	conn, err := nats.Connect(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to NATS (url: %s): %w", url, err)
+	}
+
+	logger.Info("Connected to NATS successfully", "url", url)
+
+	return &Producer{Conn: conn, Logger: logger}, nil
+}
+
+// Publish は subject にログメッセージを送信
+func (p *Producer) Publish(subject string, msg LogMessage) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal message (subject: %s, msgID: %s): %w", subject, msg.ID, err)
+	}
+
+	if err := p.Conn.Publish(subject, data); err != nil {
+		return fmt.Errorf("failed to publish message to NATS (subject: %s, msgID: %s): %w", subject, msg.ID, err)
+	}
+
+	p.Logger.Info("Message published successfully", "subject", subject, "msgID", msg.ID)
+
+	return nil
+}

--- a/internal/infra/queue/producer_test.go
+++ b/internal/infra/queue/producer_test.go
@@ -1,0 +1,126 @@
+package queue_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/infra/queue"
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+)
+
+// 共通エラー定義
+var errNATSPublish = errors.New("nats publish error")
+
+// --- モックNATS ---
+
+// MockNATSConn は NATS の Publish メソッドをモック化する構造体。
+// テスト中に呼び出し状況や送信内容を検証するために使用する。
+type MockNATSConn struct {
+	publishCalled bool   // Publish が呼ばれたかどうかのフラグ
+	subject       string // Publish に渡された subject
+	data          []byte // Publish に渡されたデータ
+	err           error  // Publish が返すエラー（任意に指定可能）
+}
+
+// Publish は Publish 呼び出し状況と引数を記録し、指定されたエラーを返すモック実装。
+func (m *MockNATSConn) Publish(subject string, data []byte) error {
+	m.publishCalled = true
+	m.subject = subject
+	m.data = data
+
+	return m.err
+}
+
+// --- テスト ---
+
+// TestProducer_Publish_Success は、ログメッセージが正常に NATS に送信される場合のテスト
+func TestProducer_Publish_Success(t *testing.T) {
+	t.Parallel()
+
+	// モックの NATS 接続とロガーを用意
+	mockConn := &MockNATSConn{
+		publishCalled: false,
+		subject:       "",
+		data:          []byte{},
+		err:           nil,
+	}
+	mockLogger := testutil.NewMockLogger()
+
+	// テスト対象の Producer を生成
+	producer := &queue.Producer{
+		Conn:   mockConn,
+		Logger: mockLogger,
+	}
+
+	// ログメッセージを作成
+	msg := queue.LogMessage{
+		ID:        "abc123",
+		TraceID:   "",
+		Timestamp: "",
+		Level:     "",
+		Service:   "",
+		Message:   "test message",
+		Metadata:  map[string]string{},
+	}
+
+	// JSON 変換して期待値を作成
+	expectedJSON, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	// メッセージ送信処理を実行
+	err = producer.Publish("logs.test", msg)
+	require.NoError(t, err)
+
+	// モックが正しく呼び出されたか検証
+	assert.True(t, mockConn.publishCalled)
+	assert.Equal(t, "logs.test", mockConn.subject)
+	assert.JSONEq(t, string(expectedJSON), string(mockConn.data))
+
+	// ログ出力の検証
+	assert.Len(t, mockLogger.Infos, 1)
+	assert.Contains(t, mockLogger.Infos[0].Msg, "Message published successfully")
+}
+
+// TestProducer_Publish_PublishError は、NATS への送信時にエラーが発生する場合のテスト
+func TestProducer_Publish_PublishError(t *testing.T) {
+	t.Parallel()
+
+	// Publish エラーを返すモック接続を用意
+	mockConn := &MockNATSConn{
+		publishCalled: false,
+		subject:       "",
+		data:          nil,
+		err:           errNATSPublish,
+	}
+	mockLogger := testutil.NewMockLogger()
+
+	// テスト対象の Producer を生成
+	producer := &queue.Producer{
+		Conn:   mockConn,
+		Logger: mockLogger,
+	}
+
+	// ログメッセージを作成
+	msg := queue.LogMessage{
+		ID:        "error123",
+		TraceID:   "",
+		Timestamp: "",
+		Level:     "",
+		Service:   "",
+		Message:   "fail",
+		Metadata:  map[string]string{},
+	}
+
+	// メッセージ送信処理を実行（失敗を期待）
+	err := producer.Publish("logs.test", msg)
+
+	// エラーが返されたことを確認
+	require.Error(t, err)
+
+	// モックが呼び出されたことを確認
+	assert.True(t, mockConn.publishCalled)
+}


### PR DESCRIPTION
## 概要
- NATS にログメッセージを送信するための Producer 実装およびユニットテストを追加しました。
- 同時に、`internal/app/usecase/log_usecase_test.go`と`internal/infra/db/log_repository_test.go`に`// 共通エラー定義`のコメントを追加しました。

## 実装内容詳細
- 新規構造体 `Producer` を実装（NATS 接続および Publish 処理を担当）
- Publish メソッド内で JSON エンコードおよびエラーハンドリングを実装
- モック可能な `NATSConn` インターフェースを導入し、テスト容易性を向上
- 正常系・異常系のユニットテストを追加し、呼び出し状況・送信内容・ロガー出力を検証
## 動作確認内容

### 実行時のコマンド:
以下のコマンドを実行し、NATS へのメッセージ送信およびログ出力を確認しました。
※ 確認には Git 管理外のローカルファイル `cmd/debug/nats/main.go` を使用しています。

```bash
go run cmd/debug/nats/main.go
```

### `cmd/debug/nats/main.go`のコード

```
package main

import (
	"os"
	"time"

	"github.com/KeitaShimura/logs-collector-api/internal/infra/queue"
	"github.com/KeitaShimura/logs-collector-api/internal/logger"
)

const waitDuration = 2 * time.Second

func main() {
	log := logger.NewLogger(
		logger.WithLevel(logger.LevelDebug),
		logger.WithWriter(os.Stdout),
	)

	url := "nats://localhost:4222"
	subject := "logs.subject.test"

	// Producer 起動
	producer, err := queue.NewProducer(url, log)
	if err != nil {
		log.Error("Failed to create producer", err)

		return
	}

	// Publish してみる
	msg := queue.LogMessage{
		ID:        "msg-001",
		Service:   "auth-service",
		Level:     "INFO",
		Message:   "NATS log message via test",
		TraceID:   "trace-001",
		Timestamp: time.Now().UTC().Format(time.RFC3339),
		Metadata:  map[string]string{"env": "dev"},
	}
	if err := producer.Publish(subject, msg); err != nil {
		log.Error("Failed to publish message", err)

		return
	}

	log.Info("Message published. Waiting to receive...")
	time.Sleep(waitDuration)
}
```

### 実行時のログ例:

```
{"time":"2025-05-03T03:07:38.696558+09:00","level":"INFO","msg":"Connected to NATS successfully","url":"nats://localhost:4222"}
{"time":"2025-05-03T03:07:38.697224+09:00","level":"INFO","msg":"Message published successfully","subject":"logs.subject.test","msgID":"msg-001"}
{"time":"2025-05-03T03:07:38.697229+09:00","level":"INFO","msg":"Message published. Waiting to receive..."}
```

### 動作環境
`docker-compose.yml` 上で以下の NATS サービスを起動し、JetStream を有効化しています。

```yaml
nats:
  image: nats:2.10-alpine
  ports:
    - "4222:4222"
  command: -js  # JetStream 有効化
```

---

この実装により、NATS を用いたログ送信基盤の実装とテストが整備され、今後のメッセージング処理の開発に向けた土台が整いました。