### PR TITLE
feat(search): add Elasticsearch client and LogSearcher for log indexing

### DIFF
--- a/internal/infra/search/client.go
+++ b/internal/infra/search/client.go
@@ -1,0 +1,30 @@
+package search
+
+import (
+	"fmt"
+
+	"github.com/elastic/go-elasticsearch/v8"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+)
+
+// NewESClient は指定されたアドレスで Elasticsearch クライアントを作成する
+func NewESClient(addresses []string, log logger.Logger) (*elasticsearch.Client, error) {
+	//nolint:exhaustruct // 必要なフィールドだけ初期化する
+	cfg := elasticsearch.Config{
+		Addresses: addresses,
+	}
+
+	// Elasticsearch クライアントを作成
+	client, err := elasticsearch.NewClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to initialize elasticsearch client (addresses: %v): %w",
+			cfg.Addresses, err,
+		)
+	}
+
+	log.Info("Elasticsearch client initialized successfully", "addresses", cfg.Addresses)
+
+	return client, nil
+}

--- a/internal/infra/search/repository.go
+++ b/internal/infra/search/repository.go
@@ -1,0 +1,57 @@
+package search
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+)
+
+// 共通エラー定義
+var ErrIndexingFailed = errors.New("indexing to Elasticsearch failed")
+
+// ESClient は Elasticsearch クライアントのインターフェース（テスト用抽象化）
+type ESClient interface {
+	Index(index string, body *bytes.Reader, o ...func(*esapi.IndexRequest)) (*esapi.Response, error)
+}
+
+// LogSearcher は Elasticsearch へのログ登録用構造体
+type LogSearcher struct {
+	client ESClient
+	log    logger.Logger
+}
+
+// NewLogSearcher は LogSearcher を作成する
+func NewLogSearcher(client ESClient, log logger.Logger) *LogSearcher {
+	return &LogSearcher{client: client, log: log}
+}
+
+// IndexLog は指定された index に logData を登録する
+func (ls *LogSearcher) IndexLog(index string, logData map[string]interface{}) error {
+	// ログデータを JSON に変換
+	data, err := json.Marshal(logData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal log (index: %s): %w", index, err)
+	}
+
+	// Elasticsearch にデータを送信
+	res, err := ls.client.Index(index, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("failed to send index request (index: %s): %w", index, err)
+	}
+	defer res.Body.Close()
+
+	// エラーステータスの場合はエラー扱い
+	if res.IsError() {
+		return fmt.Errorf("%w (index: %s, status: %s)", ErrIndexingFailed, index, res.Status())
+	}
+
+	// 成功ログ
+	ls.log.Info("Log indexed successfully", "index", index)
+
+	return nil
+}

--- a/internal/infra/search/repository_test.go
+++ b/internal/infra/search/repository_test.go
@@ -82,7 +82,7 @@ func TestLogSearcher_IndexLog_Success(t *testing.T) {
 	assert.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
 }
 
-// TestLogSearcher_IndexLog_MarshalError はログデータのマシュアル処理でエラーが発生する場合のテスト
+// TestLogSearcher_IndexLog_MarshalError はログデータのマーシャル処理でエラーが発生する場合のテスト
 func TestLogSearcher_IndexLog_MarshalError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infra/search/repository_test.go
+++ b/internal/infra/search/repository_test.go
@@ -1,0 +1,257 @@
+package search_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/infra/search"
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+)
+
+// 共通エラー定義
+var errMockIndexError = errors.New("index error")
+
+// --- モック ---
+
+// mockESClient は Elasticsearch クライアントのモック
+type mockESClient struct {
+	indexFunc func(index string, body *bytes.Reader, o ...func(*esapi.IndexRequest)) (*esapi.Response, error)
+}
+
+// Index はモックの Index メソッド
+func (m *mockESClient) Index(
+	index string,
+	body *bytes.Reader,
+	o ...func(*esapi.IndexRequest),
+) (*esapi.Response, error) {
+	return m.indexFunc(index, body, o...)
+}
+
+// errorCloser は Close 時にフラグを立てるモック
+type errorCloser struct {
+	io.Reader
+	closed bool
+}
+
+// Close は closed フラグを true にするモック実装
+func (e *errorCloser) Close() error {
+	e.closed = true
+
+	return nil
+}
+
+// --- テスト ---
+
+// TestLogSearcher_IndexLog_Success はログが正常にインデックスされる場合のテスト
+func TestLogSearcher_IndexLog_Success(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーとモックElasticsearchクライアントを準備
+	mockLogger := testutil.NewMockLogger()
+	mockClient := &mockESClient{
+		indexFunc: func(_ string, _ *bytes.Reader, _ ...func(*esapi.IndexRequest)) (*esapi.Response, error) {
+			// 正常系のレスポンスを返す
+			return &esapi.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(bytes.NewBufferString("ok")),
+			}, nil
+		},
+	}
+
+	// 検索者を作成
+	searcher := search.NewLogSearcher(mockClient, mockLogger)
+
+	// テスト用ログデータ
+	logData := map[string]interface{}{"message": "test log"}
+
+	// インデックス登録を実行
+	err := searcher.IndexLog("test-index", logData)
+	// エラーがないことを確認
+	require.NoError(t, err)
+
+	// ログに正常メッセージが記録されていることを確認
+	assert.Len(t, mockLogger.Infos, 1)
+	assert.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
+}
+
+// TestLogSearcher_IndexLog_MarshalError はログデータのマシュアル処理でエラーが発生する場合のテスト
+func TestLogSearcher_IndexLog_MarshalError(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーを準備（indexFuncは使わない）
+	mockLogger := testutil.NewMockLogger()
+	mockClient := &mockESClient{
+		indexFunc: nil,
+	}
+
+	// 検索者を作成
+	searcher := search.NewLogSearcher(mockClient, mockLogger)
+
+	// 故意にエンコードエラーを起こす不正なデータを準備
+	invalidData := map[string]interface{}{"invalid": func() {}}
+
+	// インデックス登録を実行
+	err := searcher.IndexLog("test-index", invalidData)
+	// エラーが発生することを確認
+	require.Error(t, err)
+
+	// 返却されたエラーメッセージに期待する内容が含まれていることを確認
+	assert.Contains(t, err.Error(), "failed to marshal log")
+}
+
+// TestLogSearcher_IndexLog_IndexError はElasticsearchへのインデックスリクエストでエラーが発生する場合のテスト
+func TestLogSearcher_IndexLog_IndexError(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーとエラーを返すモッククライアントを準備
+	mockLogger := testutil.NewMockLogger()
+	mockClient := &mockESClient{
+		indexFunc: func(_ string, _ *bytes.Reader, _ ...func(*esapi.IndexRequest)) (*esapi.Response, error) {
+			return nil, errMockIndexError
+		},
+	}
+
+	// 検索者を作成
+	searcher := search.NewLogSearcher(mockClient, mockLogger)
+
+	// テスト用ログデータ
+	logData := map[string]interface{}{"message": "test log"}
+
+	// インデックス登録を実行
+	err := searcher.IndexLog("test-index", logData)
+	// エラーが発生することを確認
+	require.Error(t, err)
+
+	// 返却されたエラーメッセージに期待する内容が含まれていることを確認
+	assert.Contains(t, err.Error(), "failed to send index request")
+}
+
+// TestLogSearcher_IndexLog_ResponseError はElasticsearchのレスポンスでエラーが返される場合のテスト
+func TestLogSearcher_IndexLog_ResponseError(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーとレスポンスエラーを返すモッククライアントを準備
+	mockLogger := testutil.NewMockLogger()
+	mockClient := &mockESClient{
+		indexFunc: func(_ string, _ *bytes.Reader, _ ...func(*esapi.IndexRequest)) (*esapi.Response, error) {
+			return &esapi.Response{
+				StatusCode: http.StatusInternalServerError,
+				Header:     http.Header{},
+				Body:       io.NopCloser(bytes.NewBufferString("error")),
+			}, nil
+		},
+	}
+
+	// 検索者を作成
+	searcher := search.NewLogSearcher(mockClient, mockLogger)
+
+	// テスト用ログデータ
+	logData := map[string]interface{}{"message": "test log"}
+
+	// インデックス登録を実行
+	err := searcher.IndexLog("test-index", logData)
+	// エラーが発生することを確認
+	require.Error(t, err)
+
+	// 返却されたエラーメッセージに期待する内容が含まれていることを確認
+	assert.Contains(t, err.Error(), "indexing to Elasticsearch failed")
+}
+
+// TestLogSearcher_IndexLog_CloseError はレスポンスボディのClose時にエラーが発生しても処理が成功することを確認するテスト
+func TestLogSearcher_IndexLog_CloseError(t *testing.T) {
+	t.Parallel()
+
+	mockLogger := testutil.NewMockLogger()
+	mockBody := &errorCloser{
+		Reader: bytes.NewBufferString("ok"),
+		closed: false, // 明示的に初期化
+	}
+	mockClient := &mockESClient{
+		indexFunc: func(_ string, _ *bytes.Reader, _ ...func(*esapi.IndexRequest)) (*esapi.Response, error) {
+			return &esapi.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       mockBody,
+			}, nil
+		},
+	}
+
+	searcher := search.NewLogSearcher(mockClient, mockLogger)
+
+	logData := map[string]interface{}{"message": "test log"}
+
+	// インデックス登録を実行し、エラーが発生しないことを確認
+	err := searcher.IndexLog("test-index", logData)
+	require.NoError(t, err)
+
+	// Close が呼ばれたことを確認
+	assert.True(t, mockBody.closed, "response body should be closed")
+
+	// ログに正常メッセージが記録されていることを確認
+	assert.Len(t, mockLogger.Infos, 1)
+	assert.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
+}
+
+// TestLogSearcher_IndexLog_CreatedStatus はElasticsearchが201ステータス（Created）を返した場合でも成功扱いになることを確認するテスト
+func TestLogSearcher_IndexLog_CreatedStatus(t *testing.T) {
+	t.Parallel()
+
+	mockLogger := testutil.NewMockLogger()
+	mockClient := &mockESClient{
+		indexFunc: func(_ string, _ *bytes.Reader, _ ...func(*esapi.IndexRequest)) (*esapi.Response, error) {
+			return &esapi.Response{
+				StatusCode: http.StatusCreated, // 201
+				Header:     http.Header{},
+				Body:       io.NopCloser(bytes.NewBufferString("created")),
+			}, nil
+		},
+	}
+
+	searcher := search.NewLogSearcher(mockClient, mockLogger)
+
+	logData := map[string]interface{}{"message": "test log"}
+
+	// インデックス登録を実行し、エラーが発生しないことを確認
+	err := searcher.IndexLog("test-index", logData)
+	require.NoError(t, err)
+
+	// ログに正常メッセージが記録されていることを確認
+	assert.Len(t, mockLogger.Infos, 1)
+	assert.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
+}
+
+// TestLogSearcher_IndexLog_NilBody はレスポンスボディが空の場合でも処理が成功することを確認するテスト
+func TestLogSearcher_IndexLog_NilBody(t *testing.T) {
+	t.Parallel()
+
+	mockLogger := testutil.NewMockLogger()
+	mockClient := &mockESClient{
+		indexFunc: func(_ string, _ *bytes.Reader, _ ...func(*esapi.IndexRequest)) (*esapi.Response, error) {
+			return &esapi.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(bytes.NewBufferString("")), // 空のBodyを模擬
+			}, nil
+		},
+	}
+
+	searcher := search.NewLogSearcher(mockClient, mockLogger)
+
+	logData := map[string]interface{}{"message": "test log"}
+
+	// インデックス登録を実行し、panicやエラーが発生しないことを確認
+	err := searcher.IndexLog("test-index", logData)
+	require.NoError(t, err)
+
+	// ログに正常メッセージが記録されていることを確認
+	assert.Len(t, mockLogger.Infos, 1)
+	assert.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/KeitaShimura/logs-collector-api/internal/logger"
 )
 
+// 共通エラー定義
 var errSomethingBroke = errors.New("something broke")
 
 // TestLogger_InfoWarnErrorDebugOutput は各ログレベルの出力内容を検証するテスト


### PR DESCRIPTION
## 🚀 PR 概要

- Elasticsearch 連携用の `LogSearcher` 実装とそのユニットテストを追加しました。
- 同時に`internal/logger/logger_test.go`に`// 共通エラー定義`のコメントを追加しました。
---

### ✅ 主な変更内容

- **Elasticsearch クライアント初期化**
  - `search.NewESClient`: 指定されたアドレスで Elasticsearch クライアントを生成

- **LogSearcher 実装**
  - `search.NewLogSearcher`: Elasticsearch クライアントとロガーを注入して `LogSearcher` インスタンスを生成
  - `LogSearcher.IndexLog` メソッド:
    - 指定インデックスにログデータを JSON 変換して登録
    - 以下のエラーハンドリングを実装
      - JSON マーシャリングエラー
      - リクエスト送信エラー
      - レスポンスステータスエラー（4xx / 5xx）

- **ユニットテスト**
  - `search_test` パッケージ内に正常系・異常系の網羅テストを追加
    - 正常登録
    - JSON マーシャル失敗
    - リクエスト送信エラー
    - レスポンスエラー
    - レスポンス `Close` 時の挙動確認
    - 201 Created ステータスの成功扱い確認
    - 空のレスポンスボディの安全確認

---

### 🧪 テスト内容

- `go test -v -race -cover ./...` 実行済み、全ケースパスを確認済み
- ローカルの Elasticsearch 環境で軽いデバッグ実行済み
  - ※ 429 (Too Many Requests) エラーが出たため、本PRではユニットテストでの担保にとどめています

---

### 📌 補足

- 実環境（ステージング以降）での負荷試験・結合確認は別タスクで対応予定
- ローカルElasticsearchの設定・負荷調整は必要に応じて検討