### PR TITLE
feat(grpc): implement LogHandler

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,8 +43,8 @@ jobs:
         with:
           version: v1.64
           args: --timeout=5m --verbose
-          skip-cache: false
-          skip-save-cache: false
+          skip-cache: true
+          skip-save-cache: true
 
       - name: Run Tests with Coverage
         run: |

--- a/internal/app/handler/grpc/log_handler.go
+++ b/internal/app/handler/grpc/log_handler.go
@@ -1,0 +1,136 @@
+package grpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/usecase"
+	"github.com/KeitaShimura/logs-collector-api/internal/domain/model"
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+	pb "github.com/KeitaShimura/logs-collector-protos/go/logs/v1"
+)
+
+// LogHandler はログ関連のgRPCリクエストを処理するハンドラー構造体
+type LogHandler struct {
+	pb.UnimplementedLogServiceServer
+	logUseCase usecase.LogUseCase
+	logger     logger.Logger
+}
+
+// NewLogHandler は新しいLogHandlerインスタンスを作成する
+func NewLogHandler(uc usecase.LogUseCase, logger logger.Logger) *LogHandler {
+	return &LogHandler{
+		UnimplementedLogServiceServer: pb.UnimplementedLogServiceServer{},
+		logUseCase:                    uc,
+		logger:                        logger,
+	}
+}
+
+// SendLog はログ保存リクエストを受け付け、処理するgRPCメソッド
+func (h *LogHandler) SendLog(ctx context.Context, req *pb.SendLogRequest) (*pb.SendLogResponse, error) {
+	// gRPCリクエストをドメインモデルに変換
+	log := model.Log{
+		ID:        req.GetLog().GetId(),
+		TraceID:   req.GetLog().GetTraceId(),
+		Timestamp: req.GetLog().GetTimestamp().AsTime(),
+		Level:     req.GetLog().GetLevel(),
+		Service:   req.GetLog().GetService(),
+		Message:   req.GetLog().GetMessage(),
+		Metadata:  req.GetLog().GetMetadata(),
+	}
+
+	// ユースケース層にログ保存を依頼
+	if err := h.logUseCase.SendLog(ctx, &log); err != nil {
+		// 保存失敗ログ
+		h.logger.Error("failed to save log", err,
+			"ID", log.ID,
+			"TraceID", log.TraceID,
+			"Timestamp", log.Timestamp,
+			"Level", log.Level,
+			"Service", log.Service,
+			"Message", log.Message,
+			"Metadata", log.Metadata,
+		)
+
+		// 失敗レスポンスを返却（クライアントにもエラーを通知）
+		return &pb.SendLogResponse{
+			Success:      false,
+			ErrorMessage: StringPtr(err.Error()),
+		}, status.Errorf(codes.Internal, "failed to save log: %v", err)
+	}
+
+	// 保存成功ログ
+	h.logger.Info("log saved successfully",
+		"ID", log.ID,
+		"TraceID", log.TraceID,
+		"Timestamp", log.Timestamp,
+		"Level", log.Level,
+		"Service", log.Service,
+		"Message", log.Message,
+		"Metadata", log.Metadata,
+	)
+
+	// 成功レスポンスを返却
+	return &pb.SendLogResponse{
+		Success:      true,
+		ErrorMessage: nil,
+	}, nil
+}
+
+// GetLogs は指定された条件でログを取得するgRPCメソッド
+func (h *LogHandler) GetLogs(ctx context.Context, req *pb.GetLogsRequest) (*pb.GetLogsResponse, error) {
+	// ユースケース層から条件に基づきログを取得
+	logs, err := h.logUseCase.GetLogs(
+		ctx,
+		req.GetService(),
+		req.GetLevel(),
+		int(req.GetLimit()),
+		int(req.GetOffset()),
+	)
+	if err != nil {
+		// 取得失敗ログ
+		h.logger.Error("failed to get logs", err,
+			"Service", req.GetService(),
+			"Level", req.GetLevel(),
+			"Limit", req.GetLimit(),
+			"Offset", req.GetOffset(),
+		)
+
+		// gRPCエラーとして返却
+		return nil, status.Errorf(codes.Internal, "failed to get logs: %v", err)
+	}
+
+	// ドメインモデルをgRPCレスポンス形式に変換
+	pbLogs := make([]*pb.Log, 0, len(logs))
+	for _, log := range logs {
+		pbLogs = append(pbLogs, &pb.Log{
+			Id:        log.ID,
+			TraceId:   log.TraceID,
+			Timestamp: timestamppb.New(log.Timestamp),
+			Level:     log.Level,
+			Service:   log.Service,
+			Message:   log.Message,
+			Metadata:  log.Metadata,
+		})
+	}
+
+	// 成功ログ（総件数含む）
+	h.logger.Info("logs retrieved successfully",
+		"Count", len(pbLogs),
+		"Service", req.GetService(),
+		"Level", req.GetLevel(),
+		"Limit", req.GetLimit(),
+		"Offset", req.GetOffset(),
+	)
+
+	// レスポンス返却
+	return &pb.GetLogsResponse{Logs: pbLogs}, nil
+}
+
+// stringPtr は文字列をポインタに変換するヘルパー関数
+func StringPtr(s string) *string {
+	return &s
+}

--- a/internal/app/handler/grpc/log_handler_test.go
+++ b/internal/app/handler/grpc/log_handler_test.go
@@ -1,0 +1,183 @@
+package grpc_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/handler/grpc"
+	"github.com/KeitaShimura/logs-collector-api/internal/domain/model"
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+	pb "github.com/KeitaShimura/logs-collector-protos/go/logs/v1"
+)
+
+// 共通エラー定義
+var (
+	errSaveFailed  = errors.New("save failed")
+	errGetLogsFail = errors.New("get logs failed")
+)
+
+// --- setup ---
+
+// setupSendLogTest は gRPC ハンドラーと必要なモック、およびテスト用リクエストを準備するヘルパー関数
+func setupSendLogTest() (*grpc.LogHandler, *testutil.MockLogUseCase, *testutil.MockLogger, *pb.SendLogRequest) {
+	// モックユースケースとモックロガーを作成
+	mockUC := new(testutil.MockLogUseCase)
+	mockLogger := testutil.NewMockLogger()
+
+	// テスト対象の gRPC ハンドラーを初期化
+	handler := grpc.NewLogHandler(mockUC, mockLogger)
+
+	// テスト用の gRPC リクエストを準備
+	req := &pb.SendLogRequest{
+		Log: &pb.Log{
+			Id:        "1",
+			TraceId:   "trace-1",
+			Timestamp: timestamppb.Now(),
+			Level:     "info",
+			Service:   "test-service",
+			Message:   "test message",
+			Metadata:  map[string]string{"key": "value"},
+		},
+	}
+
+	return handler, mockUC, mockLogger, req
+}
+
+// --- SendLog Tests ---
+
+// TestSendLog_Success は gRPC の SendLog メソッドが正常にログを保存できる場合のテスト
+func TestSendLog_Success(t *testing.T) {
+	t.Parallel()
+
+	// テスト環境をセットアップ
+	handler, mockUC, mockLogger, req := setupSendLogTest()
+
+	// モックユースケースに正常な応答を設定
+	mockUC.On("SendLog", mock.Anything, mock.Anything).Return(nil)
+
+	// SendLog を実行
+	resp, err := handler.SendLog(t.Context(), req)
+
+	// エラーが発生しないことを確認
+	require.NoError(t, err)
+
+	// 成功フラグが true で、エラーメッセージが空であることを確認
+	require.True(t, resp.GetSuccess())
+	require.Empty(t, resp.GetErrorMessage())
+
+	// 成功ログが1件記録されていることを確認
+	require.Len(t, mockLogger.Infos, 1)
+	require.Contains(t, mockLogger.Infos[0].Msg, "log saved successfully")
+}
+
+// TestSendLog_Failure は gRPC の SendLog メソッドがログ保存に失敗した場合のテスト
+func TestSendLog_Failure(t *testing.T) {
+	t.Parallel()
+
+	handler, mockUC, mockLogger, req := setupSendLogTest()
+
+	// モックユースケースに失敗を返すよう設定
+	mockUC.On("SendLog", mock.Anything, mock.Anything).Return(errSaveFailed)
+
+	// SendLog を実行
+	resp, err := handler.SendLog(t.Context(), req)
+
+	// エラーが返ることを確認
+	require.Error(t, err)
+
+	// 成功フラグが false で、エラーメッセージが存在することを確認
+	require.False(t, resp.GetSuccess())
+	require.NotNil(t, resp.GetErrorMessage())
+
+	// エラーログが1件出力されていることを確認
+	require.Len(t, mockLogger.Errors, 1)
+	require.Contains(t, mockLogger.Errors[0].Msg, "failed to save log")
+}
+
+// --- GetLogs Tests ---
+
+// TestGetLogs_Success は gRPC の GetLogs メソッドが正常にログを取得できる場合のテスト
+func TestGetLogs_Success(t *testing.T) {
+	t.Parallel()
+
+	mockUC := new(testutil.MockLogUseCase)
+	mockLogger := testutil.NewMockLogger()
+	handler := grpc.NewLogHandler(mockUC, mockLogger)
+
+	// モックログデータを準備
+	mockLogs := []model.Log{
+		{
+			ID:        "1",
+			TraceID:   "trace-1",
+			Timestamp: timestamppb.Now().AsTime(),
+			Level:     "info",
+			Service:   "test-service",
+			Message:   "test message",
+			Metadata:  map[string]string{"key": "value"},
+		},
+	}
+
+	// モックユースケースに成功レスポンスを設定
+	mockUC.On("GetLogs", mock.Anything, "test-service", "info", 10, 0).Return(mockLogs, nil)
+
+	req := &pb.GetLogsRequest{
+		Service:   grpc.StringPtr("test-service"),
+		Level:     grpc.StringPtr("info"),
+		Limit:     10,
+		Offset:    0,
+		StartTime: nil,
+		EndTime:   nil,
+	}
+
+	// GetLogs を実行
+	resp, err := handler.GetLogs(t.Context(), req)
+
+	// エラーがないことを確認
+	require.NoError(t, err)
+
+	// レスポンス内のログ件数と内容を確認
+	require.Len(t, resp.GetLogs(), 1)
+	require.Equal(t, "1", resp.GetLogs()[0].GetId())
+
+	// Info ログが1件出力されていることを確認
+	require.Len(t, mockLogger.Infos, 1)
+	require.Contains(t, mockLogger.Infos[0].Msg, "logs retrieved successfully")
+}
+
+// TestGetLogs_Failure は gRPC の GetLogs メソッドがログ取得に失敗した場合のテスト
+func TestGetLogs_Failure(t *testing.T) {
+	t.Parallel()
+
+	mockUC := new(testutil.MockLogUseCase)
+	mockLogger := testutil.NewMockLogger()
+	handler := grpc.NewLogHandler(mockUC, mockLogger)
+
+	// モックユースケースに失敗を返すよう設定
+	mockUC.On("GetLogs", mock.Anything, "test-service", "info", 10, 0).Return(nil, errGetLogsFail)
+
+	req := &pb.GetLogsRequest{
+		Service:   grpc.StringPtr("test-service"),
+		Level:     grpc.StringPtr("info"),
+		Limit:     10,
+		Offset:    0,
+		StartTime: nil,
+		EndTime:   nil,
+	}
+
+	// GetLogs を実行
+	resp, err := handler.GetLogs(t.Context(), req)
+
+	// エラーが返ることを確認
+	require.Error(t, err)
+
+	// レスポンスは nil であることを確認
+	require.Nil(t, resp)
+
+	// エラーログが1件出力されていることを確認
+	require.Len(t, mockLogger.Errors, 1)
+	require.Contains(t, mockLogger.Errors[0].Msg, "failed to get logs")
+}

--- a/internal/app/usecase/log_usecase.go
+++ b/internal/app/usecase/log_usecase.go
@@ -28,36 +28,32 @@ var (
 	ErrInvalidOffset        = errors.New("offset must be >= 0")
 )
 
-type LogUseCase struct {
+// LogUseCase はログに関連するユースケースのインターフェースを定義する
+type LogUseCase interface {
+	SendLog(ctx context.Context, log *model.Log) error
+	GetLogs(ctx context.Context, service string, level string, limit, offset int) ([]model.Log, error)
+}
+
+// LogUseCaseImpl は LogUseCase インターフェースの具体的な実装
+type LogUseCaseImpl struct {
 	logRepo repository.LogRepository
 	logger  logger.Logger
 }
 
 // NewLogUseCase は LogUseCase のインスタンスを生成する
-func NewLogUseCase(repo repository.LogRepository, log logger.Logger) *LogUseCase {
-	return &LogUseCase{
+func NewLogUseCase(repo repository.LogRepository, log logger.Logger) *LogUseCaseImpl {
+	return &LogUseCaseImpl{
 		logRepo: repo,
 		logger:  log,
 	}
 }
 
 // SendLog はログを永続化するユースケースを実行する
-func (uc *LogUseCase) SendLog(ctx context.Context, logEntry *model.Log) error {
+func (uc *LogUseCaseImpl) SendLog(ctx context.Context, logEntry *model.Log) error {
 	// 入力バリデーション（ID, TraceID, Message など）
 	if err := ValidateLog(logEntry, time.LoadLocation); err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid log entry: %v", err)
 	}
-
-	// 保存前ログ
-	uc.logger.Info("Saving log entry",
-		"ID", logEntry.ID,
-		"TraceID", logEntry.TraceID,
-		"Timestamp", logEntry.Timestamp,
-		"Service", logEntry.Service,
-		"Level", logEntry.Level,
-		"Message", logEntry.Message,
-		"Metadata", logEntry.Metadata,
-	)
 
 	// 永続化
 	if err := uc.logRepo.SendLog(ctx, logEntry); err != nil {
@@ -89,7 +85,7 @@ func (uc *LogUseCase) SendLog(ctx context.Context, logEntry *model.Log) error {
 }
 
 // GetLogs は指定された条件に一致するログを取得する
-func (uc *LogUseCase) GetLogs(
+func (uc *LogUseCaseImpl) GetLogs(
 	ctx context.Context,
 	service string,
 	level string,
@@ -100,14 +96,6 @@ func (uc *LogUseCase) GetLogs(
 	if err := ValidateLogQueryParams(service, level, limit, offset); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid request: %v", err)
 	}
-
-	// 取得開始ログ
-	uc.logger.Info("Getting logs",
-		"Service", service,
-		"Level", level,
-		"Limit", limit,
-		"Offset", offset,
-	)
 
 	// 永続層から取得
 	logs, err := uc.logRepo.GetLogs(ctx, service, level, limit, offset)

--- a/internal/app/usecase/log_usecase_test.go
+++ b/internal/app/usecase/log_usecase_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -69,7 +68,7 @@ func (m *mockLogRepository) GetLogs(
 // --- setup ---
 
 // setup はモックリポジトリ、モックロガー、ユースケースを初期化して返す
-func setup() (*mockLogRepository, *testutil.MockLogger, *usecase.LogUseCase) {
+func setup() (*mockLogRepository, *testutil.MockLogger, *usecase.LogUseCaseImpl) {
 	mockRepo := new(mockLogRepository)
 	mockLogger := testutil.NewMockLogger()
 	uc := usecase.NewLogUseCase(mockRepo, mockLogger)
@@ -106,9 +105,8 @@ func TestLogUseCase_SendLog_Success(t *testing.T) {
 
 	// ログが保存前後で2回記録されていることを確認
 	// 保存前のログと保存後のログがそれぞれ1回ずつ記録される
-	assert.Len(t, logger.Infos, 2)
-	assert.Contains(t, logger.Infos[0].Msg, "Saving log entry")
-	assert.Contains(t, logger.Infos[1].Msg, "Log entry saved successfully")
+	require.Len(t, logger.Infos, 1)
+	require.Contains(t, logger.Infos[0].Msg, "Log entry saved successfully")
 }
 
 // TestLogUseCase_SendLog_ValidationError はログエントリにバリデーションエラーがある場合のテスト
@@ -134,8 +132,8 @@ func TestLogUseCase_SendLog_ValidationError(t *testing.T) {
 
 	// エラーステータスコードが InvalidArgument であることを確認
 	st, ok := status.FromError(err)
-	assert.True(t, ok)
-	assert.Equal(t, codes.InvalidArgument, st.Code())
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
 }
 
 // TestLogUseCase_SendLog_RepositoryError はリポジトリでエラーが発生した場合のテスト
@@ -164,13 +162,13 @@ func TestLogUseCase_SendLog_RepositoryError(t *testing.T) {
 	// エラーが Internal コードで返されることを確認
 	require.Error(t, err)
 	st, ok := status.FromError(err)
-	assert.True(t, ok)
-	assert.Equal(t, codes.Internal, st.Code())
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, st.Code())
 
 	// エラーログが1件記録されていることを確認
 	// "Failed to save log entry" のメッセージが含まれているか確認
-	assert.Len(t, logger.Errors, 1)
-	assert.Contains(t, logger.Errors[0].Msg, "Failed to save log entry")
+	require.Len(t, logger.Errors, 1)
+	require.Contains(t, logger.Errors[0].Msg, "Failed to save log entry")
 }
 
 // --- GetLogs Tests ---
@@ -199,10 +197,11 @@ func TestLogUseCase_GetLogs_Success(t *testing.T) {
 	logs, err := logUseCase.GetLogs(ctx, "user", "INFO", 10, 0)
 	require.NoError(t, err)
 	// 返されるログが期待した値であることを確認
-	assert.Equal(t, expected, logs)
+	require.Equal(t, expected, logs)
 
 	// ログが2回記録されていることを確認（取得開始と取得成功）
-	assert.Len(t, logger.Infos, 2)
+	require.Len(t, logger.Infos, 1)
+	require.Contains(t, logger.Infos[0].Msg, "Logs retrieved successfully")
 }
 
 // TestLogUseCase_GetLogs_InvalidArgs は無効な引数が渡された場合のテスト
@@ -217,8 +216,8 @@ func TestLogUseCase_GetLogs_InvalidArgs(t *testing.T) {
 
 	// エラーのステータスコードが InvalidArgument であることを確認
 	st, ok := status.FromError(err)
-	assert.True(t, ok)
-	assert.Equal(t, codes.InvalidArgument, st.Code())
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
 }
 
 // TestLogUseCase_GetLogs_RepositoryError はリポジトリでエラーが発生した場合のテスト
@@ -236,12 +235,12 @@ func TestLogUseCase_GetLogs_RepositoryError(t *testing.T) {
 
 	// エラーが Internal コードで返されることを確認
 	st, ok := status.FromError(err)
-	assert.True(t, ok)
-	assert.Equal(t, codes.Internal, st.Code())
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, st.Code())
 
 	// エラーログが1件記録されていることを確認
-	assert.Len(t, logger.Errors, 1)
-	assert.Contains(t, logger.Errors[0].Msg, "Failed to get logs")
+	require.Len(t, logger.Errors, 1)
+	require.Contains(t, logger.Errors[0].Msg, "Failed to get logs")
 }
 
 // TestLogUseCase_GetLogs_NotFound はログが見つからなかった場合のテスト
@@ -259,8 +258,8 @@ func TestLogUseCase_GetLogs_NotFound(t *testing.T) {
 
 	// エラーのステータスコードが NotFound であることを確認
 	st, ok := status.FromError(err)
-	assert.True(t, ok)
-	assert.Equal(t, codes.NotFound, st.Code())
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, st.Code())
 }
 
 // --- validateLog Tests ---
@@ -303,7 +302,7 @@ func TestValidateLog_NilLog(t *testing.T) {
 	// ValidateLog を呼び出して、nil ログがエラーになることを確認
 	err := usecase.ValidateLog(log, timeLoadLocation)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "log entry is nil")
+	require.Contains(t, err.Error(), "log entry is nil")
 }
 
 // TestValidateLog_InvalidMessage はログメッセージが空である場合の異常系テスト
@@ -328,7 +327,7 @@ func TestValidateLog_InvalidMessage(t *testing.T) {
 	// メッセージが空である場合、エラーが発生することを確認
 	err := usecase.ValidateLog(log, timeLoadLocation)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "message must not be empty")
+	require.Contains(t, err.Error(), "message must not be empty")
 }
 
 // TestValidateLog_InvalidLevel はログレベルが空である場合の異常系テスト
@@ -353,7 +352,7 @@ func TestValidateLog_InvalidLevel(t *testing.T) {
 	// ログレベルが空の場合、エラーが発生することを確認
 	err := usecase.ValidateLog(log, timeLoadLocation)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "level must not be empty")
+	require.Contains(t, err.Error(), "level must not be empty")
 }
 
 // TestValidateLog_InvalidService はサービス名が空である場合の異常系テスト
@@ -378,7 +377,7 @@ func TestValidateLog_InvalidService(t *testing.T) {
 	// サービス名が空の場合、エラーが発生することを確認
 	err := usecase.ValidateLog(log, timeLoadLocation)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "service must not be empty")
+	require.Contains(t, err.Error(), "service must not be empty")
 }
 
 // TestValidateLog_InvalidIDFormat はログIDが無効な場合の異常系テスト
@@ -403,7 +402,7 @@ func TestValidateLog_InvalidIDFormat(t *testing.T) {
 	// 無効なID形式の場合、エラーが発生することを確認
 	err := usecase.ValidateLog(log, timeLoadLocation)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid ID format")
+	require.Contains(t, err.Error(), "invalid ID format")
 }
 
 // TestValidateLog_InvalidTraceIDFormat は TraceID が無効な場合の異常系テスト
@@ -428,7 +427,7 @@ func TestValidateLog_InvalidTraceIDFormat(t *testing.T) {
 	// 無効なTraceID形式の場合、エラーが発生することを確認
 	err := usecase.ValidateLog(log, timeLoadLocation)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid TraceID format")
+	require.Contains(t, err.Error(), "invalid TraceID format")
 }
 
 // TestValidateLog_ValidTimestamp は Timestamp がゼロ値の場合に補完されることを確認するテスト
@@ -453,7 +452,7 @@ func TestValidateLog_ValidTimestamp(t *testing.T) {
 	// Timestamp がゼロ値の場合、補完されることを確認
 	err := usecase.ValidateLog(log, timeLoadLocation)
 	require.NoError(t, err)
-	assert.False(t, log.Timestamp.IsZero(), "Timestamp should not be zero after validation")
+	require.False(t, log.Timestamp.IsZero(), "Timestamp should not be zero after validation")
 }
 
 // TestValidateLog_InvalidTimeZone は無効なタイムゾーンの場合の異常系テスト
@@ -481,7 +480,7 @@ func TestValidateLog_InvalidTimeZone(t *testing.T) {
 
 	// エラーが発生することを確認
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid time zone")
+	require.Contains(t, err.Error(), "invalid time zone")
 }
 
 // --- validateLogQueryParams Tests ---
@@ -500,7 +499,7 @@ func TestValidateLogQueryParams_InvalidService(t *testing.T) {
 
 	err := usecase.ValidateLogQueryParams("", "INFO", 10, 0)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "service must not be empty")
+	require.Contains(t, err.Error(), "service must not be empty")
 }
 
 // TestValidateLogQueryParams_InvalidLevel はレベルが空である場合の異常系テスト
@@ -509,7 +508,7 @@ func TestValidateLogQueryParams_InvalidLevel(t *testing.T) {
 
 	err := usecase.ValidateLogQueryParams("auth", "", 10, 0)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "level must not be empty")
+	require.Contains(t, err.Error(), "level must not be empty")
 }
 
 // TestValidateLogQueryParams_InvalidLimit はリミットが0または負の値である場合の異常系テスト
@@ -518,7 +517,7 @@ func TestValidateLogQueryParams_InvalidLimit(t *testing.T) {
 
 	err := usecase.ValidateLogQueryParams("auth", "INFO", -1, 0)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "limit must be greater than 0")
+	require.Contains(t, err.Error(), "limit must be greater than 0")
 }
 
 // TestValidateLogQueryParams_InvalidOffset はオフセットが負の値である場合の異常系テスト
@@ -527,5 +526,5 @@ func TestValidateLogQueryParams_InvalidOffset(t *testing.T) {
 
 	err := usecase.ValidateLogQueryParams("auth", "INFO", 10, -1)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "offset must be >= 0")
+	require.Contains(t, err.Error(), "offset must be >= 0")
 }

--- a/internal/infra/queue/producer_test.go
+++ b/internal/infra/queue/producer_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/KeitaShimura/logs-collector-api/internal/infra/queue"
@@ -15,7 +14,7 @@ import (
 // 共通エラー定義
 var errNATSPublish = errors.New("nats publish error")
 
-// --- モックNATS ---
+// --- Mock NATS ---
 
 // MockNATSConn は NATS の Publish メソッドをモック化する構造体。
 // テスト中に呼び出し状況や送信内容を検証するために使用する。
@@ -35,7 +34,7 @@ func (m *MockNATSConn) Publish(subject string, data []byte) error {
 	return m.err
 }
 
-// --- テスト ---
+// --- Publish Tests ---
 
 // TestProducer_Publish_Success は、ログメッセージが正常に NATS に送信される場合のテスト
 func TestProducer_Publish_Success(t *testing.T) {
@@ -76,13 +75,13 @@ func TestProducer_Publish_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	// モックが正しく呼び出されたか検証
-	assert.True(t, mockConn.publishCalled)
-	assert.Equal(t, "logs.test", mockConn.subject)
-	assert.JSONEq(t, string(expectedJSON), string(mockConn.data))
+	require.True(t, mockConn.publishCalled)
+	require.Equal(t, "logs.test", mockConn.subject)
+	require.JSONEq(t, string(expectedJSON), string(mockConn.data))
 
 	// ログ出力の検証
-	assert.Len(t, mockLogger.Infos, 1)
-	assert.Contains(t, mockLogger.Infos[0].Msg, "Message published successfully")
+	require.Len(t, mockLogger.Infos, 1)
+	require.Contains(t, mockLogger.Infos[0].Msg, "Message published successfully")
 }
 
 // TestProducer_Publish_PublishError は、NATS への送信時にエラーが発生する場合のテスト
@@ -122,5 +121,5 @@ func TestProducer_Publish_PublishError(t *testing.T) {
 	require.Error(t, err)
 
 	// モックが呼び出されたことを確認
-	assert.True(t, mockConn.publishCalled)
+	require.True(t, mockConn.publishCalled)
 }

--- a/internal/infra/search/repository_test.go
+++ b/internal/infra/search/repository_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/elastic/go-elasticsearch/v8/esapi"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/KeitaShimura/logs-collector-api/internal/infra/search"
@@ -18,7 +17,7 @@ import (
 // 共通エラー定義
 var errMockIndexError = errors.New("index error")
 
-// --- モック ---
+// --- Mocks ---
 
 // mockESClient は Elasticsearch クライアントのモック
 type mockESClient struct {
@@ -47,7 +46,7 @@ func (e *errorCloser) Close() error {
 	return nil
 }
 
-// --- テスト ---
+// --- IndexLog Tests ---
 
 // TestLogSearcher_IndexLog_Success はログが正常にインデックスされる場合のテスト
 func TestLogSearcher_IndexLog_Success(t *testing.T) {
@@ -78,8 +77,8 @@ func TestLogSearcher_IndexLog_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	// ログに正常メッセージが記録されていることを確認
-	assert.Len(t, mockLogger.Infos, 1)
-	assert.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
+	require.Len(t, mockLogger.Infos, 1)
+	require.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
 }
 
 // TestLogSearcher_IndexLog_MarshalError はログデータのマーシャル処理でエラーが発生する場合のテスト
@@ -104,7 +103,7 @@ func TestLogSearcher_IndexLog_MarshalError(t *testing.T) {
 	require.Error(t, err)
 
 	// 返却されたエラーメッセージに期待する内容が含まれていることを確認
-	assert.Contains(t, err.Error(), "failed to marshal log")
+	require.Contains(t, err.Error(), "failed to marshal log")
 }
 
 // TestLogSearcher_IndexLog_IndexError はElasticsearchへのインデックスリクエストでエラーが発生する場合のテスト
@@ -131,7 +130,7 @@ func TestLogSearcher_IndexLog_IndexError(t *testing.T) {
 	require.Error(t, err)
 
 	// 返却されたエラーメッセージに期待する内容が含まれていることを確認
-	assert.Contains(t, err.Error(), "failed to send index request")
+	require.Contains(t, err.Error(), "failed to send index request")
 }
 
 // TestLogSearcher_IndexLog_ResponseError はElasticsearchのレスポンスでエラーが返される場合のテスト
@@ -162,7 +161,7 @@ func TestLogSearcher_IndexLog_ResponseError(t *testing.T) {
 	require.Error(t, err)
 
 	// 返却されたエラーメッセージに期待する内容が含まれていることを確認
-	assert.Contains(t, err.Error(), "indexing to Elasticsearch failed")
+	require.Contains(t, err.Error(), "indexing to Elasticsearch failed")
 }
 
 // TestLogSearcher_IndexLog_CloseError はレスポンスボディのClose時にエラーが発生しても処理が成功することを確認するテスト
@@ -193,11 +192,11 @@ func TestLogSearcher_IndexLog_CloseError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Close が呼ばれたことを確認
-	assert.True(t, mockBody.closed, "response body should be closed")
+	require.True(t, mockBody.closed, "response body should be closed")
 
 	// ログに正常メッセージが記録されていることを確認
-	assert.Len(t, mockLogger.Infos, 1)
-	assert.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
+	require.Len(t, mockLogger.Infos, 1)
+	require.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
 }
 
 // TestLogSearcher_IndexLog_CreatedStatus はElasticsearchが201ステータス（Created）を返した場合でも成功扱いになることを確認するテスト
@@ -224,8 +223,8 @@ func TestLogSearcher_IndexLog_CreatedStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	// ログに正常メッセージが記録されていることを確認
-	assert.Len(t, mockLogger.Infos, 1)
-	assert.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
+	require.Len(t, mockLogger.Infos, 1)
+	require.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
 }
 
 // TestLogSearcher_IndexLog_NilBody はレスポンスボディが空の場合でも処理が成功することを確認するテスト
@@ -252,6 +251,6 @@ func TestLogSearcher_IndexLog_NilBody(t *testing.T) {
 	require.NoError(t, err)
 
 	// ログに正常メッセージが記録されていることを確認
-	assert.Len(t, mockLogger.Infos, 1)
-	assert.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
+	require.Len(t, mockLogger.Infos, 1)
+	require.Contains(t, mockLogger.Infos[0].Msg, "Log indexed successfully")
 }

--- a/internal/testutil/mock_log_usecase.go
+++ b/internal/testutil/mock_log_usecase.go
@@ -1,0 +1,51 @@
+package testutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/domain/model"
+)
+
+// 共通エラー定義
+var (
+	ErrMockSendLog        = errors.New("mock SendLog error")
+	ErrMockGetLogs        = errors.New("mock GetLogs error")
+	ErrUnexpectedMockType = errors.New("unexpected mock type")
+)
+
+// MockLogUseCase は LogUseCase インターフェースのモック実装
+type MockLogUseCase struct {
+	mock.Mock
+}
+
+// SendLog はモックの SendLog メソッドを呼び出す
+func (m *MockLogUseCase) SendLog(ctx context.Context, log *model.Log) error {
+	args := m.Called(ctx, log)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("%w: %w", ErrMockSendLog, err)
+	}
+
+	return nil
+}
+
+// GetLogs はモックの GetLogs メソッドを呼び出す
+func (m *MockLogUseCase) GetLogs(ctx context.Context, service, level string, limit, offset int) ([]model.Log, error) {
+	args := m.Called(ctx, service, level, limit, offset)
+
+	v := args.Get(0)
+	logs, ok := v.([]model.Log)
+
+	if !ok {
+		return nil, fmt.Errorf("%w: %T", ErrUnexpectedMockType, v)
+	}
+
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrMockGetLogs, err)
+	}
+
+	return logs, nil
+}


### PR DESCRIPTION
## 概要

このPRでは、主に gRPC サーバのリクエスト処理、ユースケース層の整備、MockLogUseCase の追加、テストコードの整備を含んでいます。

---

### 実装内容

- **gRPC LogHandler の新規実装**
  - `SendLog` および `GetLogs` メソッドを追加し、ログ保存・取得リクエストを処理
  - domain layer との接続（UseCase → Repository）を行い、永続化層と連携
  - 成功・失敗時のログ出力（Info, Error）を統一的に記録
  - gRPC の `status.Errorf` を用いた詳細なステータスコード管理

- **UseCase層の整備**
  - `LogUseCase` インターフェースと `LogUseCaseImpl` 実装を分離

- **MockLogUseCase の追加**
  - UseCase 層のユニットテスト用にモックを追加
  - `SendLog`, `GetLogs` メソッドのモック応答とエラーシナリオを制御可能に

---

### テストコードのリファクタリング

- **コメントの微修正**
- **assert → require への移行**
  - テスト失敗時に後続処理を止める目的で、`assert` を `require` に変更
  - 意図しない進行を防ぎ、テストの安全性を向上

---

### CI 設定の変更

- **golangci-lint キャッシュの無効化**
  - `.github/workflows/ci.yaml` にて `skip-cache: true` および `skip-save-cache: true` を設定
  - **背景:** 古いキャッシュの影響で lint エラーが発生する事例があったため、常にクリーンな状態で lint を実行するよう改善
  - これにより、キャッシュ由来の不整合を防ぎ、確実な lint 結果が得られるようにする