### PR TITLE
feat(server): setup Echo router with Swagger

### DIFF
--- a/internal/pkg/server/router.go
+++ b/internal/pkg/server/router.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"github.com/labstack/echo/v4"
+	echoSwagger "github.com/swaggo/echo-swagger"
+
+	// Swagger docs を読み込むための blank import（swag により生成される）
+	_ "github.com/KeitaShimura/logs-collector-api/docs"
+	"github.com/KeitaShimura/logs-collector-api/internal/app/handler/rest"
+	customValidator "github.com/KeitaShimura/logs-collector-api/internal/pkg/validator"
+)
+
+// NewRouter は Echo サーバーのルーターを初期化し、エンドポイントを登録する
+func NewRouter(logHandler *rest.LogHandler) *echo.Echo {
+	// Echo インスタンスを作成
+	echoServer := echo.New()
+
+	// カスタムバリデーターを設定（Echo のバリデーション用）
+	echoServer.Validator = customValidator.NewValidator()
+
+	// Swagger UI エンドポイントを登録
+	echoServer.GET("/swagger/*", echoSwagger.WrapHandler)
+
+	api := echoServer.Group("/api")
+
+	api.POST("/logs", logHandler.SendLog)
+	api.GET("/logs", logHandler.GetLogs)
+
+	return echoServer
+}

--- a/internal/pkg/server/router_test.go
+++ b/internal/pkg/server/router_test.go
@@ -1,0 +1,147 @@
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/handler/rest"
+	"github.com/KeitaShimura/logs-collector-api/internal/domain/model"
+	"github.com/KeitaShimura/logs-collector-api/internal/pkg/server"
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+)
+
+// TestSwaggerRoute はSwaggerルートが登録されていることを確認するテスト
+func TestSwaggerRoute(t *testing.T) {
+	t.Parallel()
+
+	// モックのユースケースとロガーを準備
+	mockUC := new(testutil.MockLogUseCase)
+	mockLogger := testutil.NewMockLogger()
+	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger))
+
+	// Swaggerドキュメント用のGETリクエストを作成
+	req := httptest.NewRequest(http.MethodGet, "/swagger/index.html", nil)
+	rec := httptest.NewRecorder()
+
+	// リクエストをサーバーに送信
+	echoServer.ServeHTTP(rec, req)
+
+	// 404でないことを確認（Swaggerルートが存在することを確認）
+	require.NotEqual(t, http.StatusNotFound, rec.Code, "Swagger route should be registered")
+}
+
+// TestPostLogsRoute_Success はPOST /api/logsルートが正常に登録され、モックが呼ばれることを確認するテスト
+func TestPostLogsRoute_Success(t *testing.T) {
+	t.Parallel()
+
+	// モックユースケースのSendLogを成功レスポンスに設定
+	mockUC := new(testutil.MockLogUseCase)
+	mockUC.On("SendLog", mock.Anything, mock.AnythingOfType("*model.Log")).Return(nil)
+
+	mockLogger := testutil.NewMockLogger()
+	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger))
+
+	// テスト用のPOSTリクエストボディを作成
+	reqBody := rest.SendLogRequest{
+		ID:        "",
+		TraceID:   "",
+		Message:   "test message",
+		Level:     "info",
+		Service:   "test-service",
+		Timestamp: time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Metadata:  nil,
+	}
+
+	body, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	// POSTリクエストを作成
+	req := httptest.NewRequest(http.MethodPost, "/api/logs", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+
+	rec := httptest.NewRecorder()
+
+	// リクエストをサーバーに送信
+	echoServer.ServeHTTP(rec, req)
+
+	// 404ではないこと、および200 OKであることを確認
+	require.NotEqual(t, http.StatusNotFound, rec.Code, "POST /api/logs route should be registered")
+	require.Equal(t, http.StatusOK, rec.Code, "POST /api/logs should return 200 OK")
+
+	// モックの期待が満たされていることを確認
+	mockUC.AssertExpectations(t)
+}
+
+// TestPostLogsRoute_NotFound は存在しないPOSTルートが404を返すことを確認するテスト
+func TestPostLogsRoute_NotFound(t *testing.T) {
+	t.Parallel()
+
+	// モックのユースケースとロガーを準備
+	mockUC := new(testutil.MockLogUseCase)
+	mockLogger := testutil.NewMockLogger()
+	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger))
+
+	// 存在しないPOSTルートへのリクエストを作成
+	req := httptest.NewRequest(http.MethodPost, "/api/unknown", nil)
+	rec := httptest.NewRecorder()
+
+	// リクエストをサーバーに送信
+	echoServer.ServeHTTP(rec, req)
+
+	// 404 Not Found を期待
+	require.Equal(t, http.StatusNotFound, rec.Code, "Unknown route should return 404")
+}
+
+// TestGetLogsRoute_Success はGET /api/logsルートが正常に登録され200を返すことを確認するテスト
+func TestGetLogsRoute_Success(t *testing.T) {
+	t.Parallel()
+
+	// モックユースケースのGetLogsを成功レスポンスに設定
+	mockUC := new(testutil.MockLogUseCase)
+	mockUC.On("GetLogs", mock.Anything, "", "", 100, 0).Return([]model.Log{}, nil)
+
+	mockLogger := testutil.NewMockLogger()
+	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger))
+
+	// GETリクエストを作成
+	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	rec := httptest.NewRecorder()
+
+	// リクエストをサーバーに送信
+	echoServer.ServeHTTP(rec, req)
+
+	// 404ではないこと、および200 OKであることを確認
+	require.NotEqual(t, http.StatusNotFound, rec.Code, "GET /api/logs route should be registered")
+	require.Equal(t, http.StatusOK, rec.Code, "GET /api/logs should return 200 OK")
+
+	// モックの期待が満たされていることを確認
+	mockUC.AssertExpectations(t)
+}
+
+// TestGetLogsRoute_NotFound は存在しないGETルートが404を返すことを確認するテスト
+func TestGetLogsRoute_NotFound(t *testing.T) {
+	t.Parallel()
+
+	// モックのユースケースとロガーを準備
+	mockUC := new(testutil.MockLogUseCase)
+	mockLogger := testutil.NewMockLogger()
+	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger))
+
+	// 存在しないGETルートへのリクエストを作成
+	req := httptest.NewRequest(http.MethodGet, "/api/invalid", nil)
+	rec := httptest.NewRecorder()
+
+	// リクエストをサーバーに送信
+	echoServer.ServeHTTP(rec, req)
+
+	// 404 Not Found を期待
+	require.Equal(t, http.StatusNotFound, rec.Code, "Unknown GET route should return 404")
+}

--- a/internal/pkg/validator/custom_validator.go
+++ b/internal/pkg/validator/custom_validator.go
@@ -1,0 +1,28 @@
+package validator
+
+import (
+	"fmt"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// CustomValidator は echo のバリデーションをラップした構造体
+type CustomValidator struct {
+	validator *validator.Validate
+}
+
+// Validate は echo の Validator インターフェース実装
+func (cv *CustomValidator) Validate(i interface{}) error {
+	if err := cv.validator.Struct(i); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// NewValidator はバリデーターのインスタンスを返す
+func NewValidator() *CustomValidator {
+	return &CustomValidator{
+		validator: validator.New(),
+	}
+}

--- a/internal/pkg/validator/custom_validator_test.go
+++ b/internal/pkg/validator/custom_validator_test.go
@@ -1,0 +1,56 @@
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/pkg/validator"
+)
+
+// TestCustomValidator_Validate_Success は必須項目が正しく入力された場合にバリデーションが成功することを確認するテスト
+func TestCustomValidator_Validate_Success(t *testing.T) {
+	t.Parallel()
+
+	// カスタムバリデーターを初期化
+	validatorInstance := validator.NewValidator()
+
+	// テスト用構造体（Name は必須）
+	type TestStruct struct {
+		Name string `validate:"required"`
+	}
+
+	// 必須項目が埋まっているケース
+	s := TestStruct{Name: "ok"}
+
+	// バリデーション実行
+	err := validatorInstance.Validate(s)
+
+	// エラーがないことを確認（成功）
+	require.NoError(t, err)
+}
+
+// TestCustomValidator_Validate_Failure は必須項目が未入力の場合にバリデーションが失敗することを確認するテスト
+func TestCustomValidator_Validate_Failure(t *testing.T) {
+	t.Parallel()
+
+	// カスタムバリデーターを初期化
+	validatorInstance := validator.NewValidator()
+
+	// テスト用構造体（Name は必須）
+	type TestStruct struct {
+		Name string `validate:"required"`
+	}
+
+	// 必須項目が空のケース
+	s := TestStruct{
+		Name: "",
+	}
+
+	// バリデーション実行
+	err := validatorInstance.Validate(s)
+
+	// エラーが返ることを確認（失敗）
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "validation failed")
+}


### PR DESCRIPTION
# 概要

REST API のルーティングとバリデーション基盤の実装、およびそれに対する単体テストの整備を行いました。

## 変更内容

- **RESTサーバールーター (`server` パッケージ)**
  - Echo を用いて `/api/logs` (POST, GET) と `/swagger/*` エンドポイントを登録
  - Swagger UI のルーティングに対応

- **サーバールーターの単体テスト**
  - POST /api/logs、GET /api/logs、存在しないルート、Swaggerルートの正常系・異常系テストを追加

- **カスタムバリデーター (`validator` パッケージ)**
  - go-playground/validator を Echo 用の Validator インターフェースにラップ

- **カスタムバリデーターの単体テスト**
  - 必須項目の正常ケースと異常ケースでバリデーションが正しく動作することを検証