### PR TITLE
feat: add recovery middleware

### DIFF
--- a/internal/app/handler/rest/log_handler_test.go
+++ b/internal/app/handler/rest/log_handler_test.go
@@ -89,7 +89,7 @@ func setupParseQueryParamsTest(t *testing.T, query string) (
 	t.Helper()
 
 	// Echo サーバーを作成
-	server := echo.New()
+	echoServer := echo.New()
 
 	// モックロガーを作成（ユースケースは不要なので nil）
 	mockLogger := testutil.NewMockLogger()
@@ -101,7 +101,7 @@ func setupParseQueryParamsTest(t *testing.T, query string) (
 	// レスポンスレコーダを作成
 	rec := httptest.NewRecorder()
 
-	return handler, mockLogger, req, rec, server
+	return handler, mockLogger, req, rec, echoServer
 }
 
 // setupParseAndValidateTest は ParseAndValidateRequest のテスト用ヘルパー関数

--- a/internal/app/middleware/grpc/recovery.go
+++ b/internal/app/middleware/grpc/recovery.go
@@ -1,0 +1,56 @@
+package grpcmw
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/middleware"
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+)
+
+// RecoveryInterceptor は panic 発生時に gRPC サーバーを回復させるインターセプター
+func RecoveryInterceptor(log logger.Logger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		var resp interface{}
+
+		var err error
+
+		// done チャネルで goroutine の完了を待つ
+		done := make(chan struct{})
+
+		go func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					// panic を捕捉してログに記録
+					middleware.RecoveryHandler(log, map[string]interface{}{
+						"panic":  recovered,
+						"method": info.FullMethod,
+					})
+					// エラーに Internal ステータスを設定
+					err = status.Errorf(codes.Internal, "panic recovered: %v", recovered)
+				}
+
+				close(done) // goroutine 完了通知
+			}()
+
+			// handler 実行結果をセット（panic が起きた場合 defer が回収）
+			resp, err = handler(ctx, req)
+		}()
+		<-done // goroutine の終了を待つ
+
+		// Internal 以外のエラーを Internal にラップ
+		if err != nil && status.Code(err) != codes.Internal {
+			return nil, status.Errorf(codes.Internal, "internal error: %v", err)
+		}
+
+		return resp, err
+	}
+}

--- a/internal/app/middleware/grpc/recovery_test.go
+++ b/internal/app/middleware/grpc/recovery_test.go
@@ -1,0 +1,110 @@
+package grpcmw_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	grpcmw "github.com/KeitaShimura/logs-collector-api/internal/app/middleware/grpc"
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+)
+
+// 共通エラー定義
+var ErrHandler = errors.New("handler error")
+
+// TestRecoveryInterceptor_NormalFlow は panic やエラーがない通常フローの確認用テスト
+func TestRecoveryInterceptor_NormalFlow(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーを作成し、RecoveryInterceptor を取得
+	mockLogger := testutil.NewMockLogger()
+	interceptor := grpcmw.RecoveryInterceptor(mockLogger)
+
+	// 正常に値を返すハンドラーを用意
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	// インターセプターを実行
+	resp, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/TestMethod",
+		Server:     nil,
+	}, handler)
+
+	// エラーがないことを確認
+	require.NoError(t, err)
+	// レスポンスが期待通りであることを確認
+	require.Equal(t, "success", resp)
+	// panic や error がないため、Error ログは記録されないことを確認
+	require.Empty(t, mockLogger.Errors)
+}
+
+// TestRecoveryInterceptor_Panic はハンドラー内で panic が発生した場合の回復テスト
+func TestRecoveryInterceptor_Panic(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーを作成し、RecoveryInterceptor を取得
+	mockLogger := testutil.NewMockLogger()
+	interceptor := grpcmw.RecoveryInterceptor(mockLogger)
+
+	// panic を発生させるハンドラーを用意
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		panic("simulated panic")
+	}
+
+	// インターセプターを実行
+	resp, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/TestMethod",
+		Server:     nil,
+	}, handler)
+
+	// panic 回復後、レスポンスは nil でエラーが返ることを確認
+	require.Nil(t, resp)
+	require.Error(t, err)
+
+	// エラーが gRPC の Internal ステータスでラップされていることを確認
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, st.Code())
+
+	// エラーログが1件記録され、内容に panic 情報が含まれていることを確認
+	require.Len(t, mockLogger.Errors, 1)
+	require.Contains(t, mockLogger.Errors[0].Msg, "panic recovered")
+}
+
+// TestRecoveryInterceptor_HandlerReturnsError はハンドラーがエラーを返した場合のテスト
+func TestRecoveryInterceptor_HandlerReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーを作成し、RecoveryInterceptor を取得
+	mockLogger := testutil.NewMockLogger()
+	interceptor := grpcmw.RecoveryInterceptor(mockLogger)
+
+	// エラーを返すハンドラーを用意
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return nil, ErrHandler
+	}
+
+	// インターセプターを実行
+	resp, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/TestMethod",
+		Server:     nil,
+	}, handler)
+
+	// エラーが返ることを確認
+	require.Nil(t, resp)
+	require.Error(t, err)
+
+	// エラーが gRPC の Internal ステータスでラップされていることを確認
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, st.Code())
+
+	// panic ではないため、Error ログは記録されていないことを確認
+	require.Empty(t, mockLogger.Errors)
+}

--- a/internal/app/middleware/recovery.go
+++ b/internal/app/middleware/recovery.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"runtime/debug"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+)
+
+// RecoveryHandler は panic を回収し、詳細ログを残す共通関数
+func RecoveryHandler(log logger.Logger, contextInfo map[string]interface{}) string {
+	// スタックトレースを取得
+	stack := string(debug.Stack())
+
+	// ログ出力用のフィールドを整形
+	logFields := []interface{}{
+		"stack", stack,
+	}
+	for k, v := range contextInfo {
+		logFields = append(logFields, k, v)
+	}
+
+	// 構造化ログとして panic 内容と付随情報を記録
+	log.Error("panic recovered", nil, logFields...)
+
+	return stack
+}

--- a/internal/app/middleware/recovery_test.go
+++ b/internal/app/middleware/recovery_test.go
@@ -1,0 +1,70 @@
+package middleware_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/middleware"
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+)
+
+// TestRecoveryHandler は RecoveryHandler 関数の挙動をテストする
+func TestRecoveryHandler(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーを初期化
+	mockLogger := testutil.NewMockLogger()
+
+	// テスト用の追加コンテキスト情報を準備
+	contextInfo := map[string]interface{}{
+		"key1": "value1",
+		"key2": 123,
+	}
+
+	// RecoveryHandler を実行（panic回収とログ記録を模擬）
+	stack := middleware.RecoveryHandler(mockLogger, contextInfo)
+
+	// スタックトレースが空ではないことを確認
+	require.NotEmpty(t, stack)
+
+	// Error ログが1件出力されていることを確認
+	require.Len(t, mockLogger.Errors, 1)
+
+	logEntry := mockLogger.Errors[0]
+
+	// ログメッセージが期待通りであることを確認
+	require.Equal(t, "panic recovered", logEntry.Msg)
+
+	// 渡されたフィールドに stack, key1, key2 が含まれていることを確認
+	foundStack := false
+	foundKey1 := false
+	foundKey2 := false
+
+	for i := 0; i < len(logEntry.Args); i += 2 {
+		key := logEntry.Args[i]
+		value := logEntry.Args[i+1]
+
+		if key == "stack" {
+			foundStack = true
+
+			require.Contains(t, value, "goroutine") // スタックトレースの断片を簡易チェック
+		}
+
+		if key == "key1" && value == "value1" {
+			foundKey1 = true
+		}
+
+		if key == "key2" && value == 123 {
+			foundKey2 = true
+		}
+	}
+
+	require.True(t, foundStack, "stack field should be present")
+	require.True(t, foundKey1, "key1 field should be present")
+	require.True(t, foundKey2, "key2 field should be present")
+
+	// 他のログレベルには出力がないことを確認
+	require.Empty(t, mockLogger.Infos)
+	require.Empty(t, mockLogger.Warns)
+}

--- a/internal/app/middleware/rest/recovery.go
+++ b/internal/app/middleware/rest/recovery.go
@@ -1,0 +1,38 @@
+package restmw
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/middleware"
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+)
+
+// RecoveryMiddleware は Echo 用の panic リカバリー用ミドルウェア
+func RecoveryMiddleware(log logger.Logger) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+			defer func() {
+				if r := recover(); r != nil {
+					// 共通のリカバリーロガーを呼び出し、panic 内容を記録
+					middleware.RecoveryHandler(log, map[string]interface{}{
+						"panic":  r,
+						"path":   ctx.Request().URL.Path,
+						"method": ctx.Request().Method,
+					})
+
+					// クライアントに HTTP 500 を返却
+					if err := ctx.JSON(http.StatusInternalServerError, map[string]string{
+						"error": "internal server error",
+					}); err != nil {
+						log.Error("failed to send error response", err)
+					}
+				}
+			}()
+
+			// 通常のハンドラー処理を実行
+			return next(ctx)
+		}
+	}
+}

--- a/internal/app/middleware/rest/recovery_test.go
+++ b/internal/app/middleware/rest/recovery_test.go
@@ -1,0 +1,71 @@
+package restmw_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	restmw "github.com/KeitaShimura/logs-collector-api/internal/app/middleware/rest"
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+)
+
+// 共通エラー定義
+var ErrHandler = errors.New("handler error")
+
+func TestRecoveryMiddleware_NormalFlow(t *testing.T) {
+	t.Parallel()
+
+	echoServer := echo.New()
+	mockLogger := testutil.NewMockLogger()
+
+	// Echo サーバに RecoveryMiddleware を登録
+	echoServer.Use(restmw.RecoveryMiddleware(mockLogger))
+
+	// 正常に "OK" を返すハンドラー
+	echoServer.GET("/test", func(c echo.Context) error {
+		return c.String(http.StatusOK, "OK")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	// Echo 全体を通してリクエストを実行
+	echoServer.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "OK", rec.Body.String())
+	require.Empty(t, mockLogger.Errors)
+}
+
+// TestRecoveryMiddleware_Panic はハンドラー内で panic が発生した場合の回復テスト
+func TestRecoveryMiddleware_Panic(t *testing.T) {
+	t.Parallel()
+
+	echoServer := echo.New()
+	mockLogger := testutil.NewMockLogger()
+
+	// RecoveryMiddleware を登録
+	echoServer.Use(restmw.RecoveryMiddleware(mockLogger))
+
+	// panic を発生させるハンドラー
+	echoServer.GET("/panic", func(_ echo.Context) error {
+		panic("simulated panic")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	rec := httptest.NewRecorder()
+
+	// Echo 全体で ServeHTTP を使うことでミドルウェアを通過させる
+	echoServer.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Contains(t, rec.Body.String(), "internal server error")
+
+	// Error ログが記録されていることを確認
+	require.Len(t, mockLogger.Errors, 1)
+	require.Contains(t, mockLogger.Errors[0].Msg, "panic recovered")
+}


### PR DESCRIPTION
# PR概要

このPRでは、**panic リカバリー用の共通ミドルウェア** を追加し、REST（Echo）および gRPC 双方での耐障害性を向上させました。

---

## 🔨 主な実装内容

- **共通 RecoveryHandler 実装（`middleware` パッケージ）**
  - panic 発生時のスタックトレースを取得し、付随情報とともに構造化ログとして出力

- **REST用 RecoveryMiddleware 実装（`restmw` パッケージ）**
  - Echo サーバー用の panic 回収ミドルウェア
  - panic 発生時に HTTP 500 を返却し、詳細ログを記録

- **gRPC用 RecoveryInterceptor 実装（`grpcmw` パッケージ）**
  - gRPC サーバー用の panic 回収インターセプター
  - panic 発生時に gRPC の Internal エラーを返却し、詳細ログを記録

---

## 🧪 追加テスト

- `RecoveryHandler` のユニットテスト  
  → スタックトレース・付随情報のログ記録を検証

- REST用 `RecoveryMiddleware` テスト
  - 通常フロー（panicなし）の正常系テスト
  - panic発生時の回復と HTTP 500 応答の異常系テスト

- gRPC用 `RecoveryInterceptor` テスト
  - 通常フロー（panicなし）の正常系テスト
  - panic発生時の回復と Internal エラー返却の異常系テスト
  - handlerがエラーを返した場合の Internal エラー変換テスト

---

## 🎯 目的と効果

- REST / gRPC 双方のサーバーで panic によるプロセス全体クラッシュを防止
- 障害発生時にスタック情報を構造化ログとして記録
- 開発・運用時の障害解析の効率化を実現