### PR TITLE
feat: add logging middleware 

### DIFF
--- a/internal/app/handler/rest/log_handler.go
+++ b/internal/app/handler/rest/log_handler.go
@@ -187,8 +187,8 @@ func (h *LogHandler) GetLogs(echoCtx echo.Context) error {
 }
 
 // RespondJSON はJSONでレスポンスを返しつつ、内部エラーをラップして返す
-func RespondJSON(e echo.Context, code int, body interface{}) error {
-	if jsonErr := e.JSON(code, body); jsonErr != nil {
+func RespondJSON(echoCtx echo.Context, code int, body interface{}) error {
+	if jsonErr := echoCtx.JSON(code, body); jsonErr != nil {
 		return fmt.Errorf("failed to return JSON response: %w", jsonErr)
 	}
 
@@ -228,17 +228,17 @@ func (h *LogHandler) ParseAndValidateRequest(echoCtx echo.Context) (SendLogReque
 }
 
 // ParseQueryParams はクエリパラメータを抽出・バリデーションするヘルパー関数
-func (h *LogHandler) ParseQueryParams(ctx echo.Context) (string, string, int, int, error) {
+func (h *LogHandler) ParseQueryParams(echoCtx echo.Context) (string, string, int, int, error) {
 	// service パラメータを取得
-	service := ctx.QueryParam("service")
+	service := echoCtx.QueryParam("service")
 
 	// level パラメータを取得
-	level := ctx.QueryParam("level")
+	level := echoCtx.QueryParam("level")
 
 	// limit パラメータ（デフォルト: 100）
 	limit := 100
 
-	if limitStr := ctx.QueryParam("limit"); limitStr != "" {
+	if limitStr := echoCtx.QueryParam("limit"); limitStr != "" {
 		// limit を数値に変換
 		parsedLimit, err := strconv.Atoi(limitStr)
 		if err != nil {
@@ -262,7 +262,7 @@ func (h *LogHandler) ParseQueryParams(ctx echo.Context) (string, string, int, in
 	// offset パラメータ（デフォルト: 0）
 	offset := 0
 
-	if offsetStr := ctx.QueryParam("offset"); offsetStr != "" {
+	if offsetStr := echoCtx.QueryParam("offset"); offsetStr != "" {
 		// offset を数値に変換
 		parsedOffset, err := strconv.Atoi(offsetStr)
 		if err != nil {

--- a/internal/app/handler/rest/log_handler_test.go
+++ b/internal/app/handler/rest/log_handler_test.go
@@ -471,9 +471,9 @@ func TestRespondJSON_Success(t *testing.T) {
 	t.Parallel()
 
 	// Echoサーバーとレスポンスレコーダーをセットアップ
-	e := echo.New()
+	echoServer := echo.New()
 	rec := httptest.NewRecorder()
-	c := e.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), rec)
+	c := echoServer.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), rec)
 
 	// テスト対象関数を実行
 	err := rest.RespondJSON(c, http.StatusOK, map[string]string{"message": "ok"})

--- a/internal/app/middleware/grpc/logging.go
+++ b/internal/app/middleware/grpc/logging.go
@@ -1,0 +1,48 @@
+package grpcmw
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/middleware"
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+)
+
+// LoggingInterceptor は gRPC 呼び出し全体の構造化ログを出力する
+func LoggingInterceptor(log logger.Logger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		// 呼び出し開始時刻を記録（処理時間計測のため）
+		start := time.Now()
+
+		// 実際の gRPC ハンドラを呼び出す
+		resp, err := handler(ctx, req)
+
+		// 処理完了後の経過時間を取得
+		duration := time.Since(start)
+
+		// gRPC ステータスコードを取得（例：OK, Internal, NotFound など）
+		code := status.Code(err)
+
+		// LoggingHandler を使って構造化ログを出力
+		// trace_id や user_id などは context から LoggingHandler 側で取得
+		middleware.LoggingHandler(
+			ctx,
+			log,
+			info.FullMethod,
+			code.String(),
+			duration,
+			err,
+		)
+
+		// ハンドラの結果をそのまま返す
+		return resp, err
+	}
+}

--- a/internal/app/middleware/grpc/logging_test.go
+++ b/internal/app/middleware/grpc/logging_test.go
@@ -1,0 +1,133 @@
+package grpcmw_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/middleware"
+	grpcmw "github.com/KeitaShimura/logs-collector-api/internal/app/middleware/grpc"
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+)
+
+// TestLoggingInterceptor_InfoLog は gRPC 呼び出しが正常に完了したときに Info ログが出力されることを確認する
+func TestLoggingInterceptor_InfoLog(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーとインターセプターを準備
+	mockLogger := testutil.NewMockLogger()
+	interceptor := grpcmw.LoggingInterceptor(mockLogger)
+
+	// context にメタデータを設定（LoggingHandler 内で使用される）
+	ctx := t.Context()
+	ctx = context.WithValue(ctx, middleware.ContextKeyTraceID, "trace-123")
+	ctx = context.WithValue(ctx, middleware.ContextKeyRequestID, "req-456")
+	ctx = context.WithValue(ctx, middleware.ContextKeyUserID, "user-789")
+	ctx = context.WithValue(ctx, middleware.ContextKeyClientIP, "192.168.1.1")
+
+	// 正常レスポンスを返すハンドラーを定義
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return "ok", nil
+	}
+
+	// インターセプターを実行
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/TestMethod",
+		Server:     nil,
+	}, handler)
+
+	// 結果を検証
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp)
+
+	// Info ログが1件記録されていることを確認
+	require.Len(t, mockLogger.Infos, 1)
+	entry := mockLogger.Infos[0]
+	require.Equal(t, "request completed", entry.Msg)
+
+	// ログに含まれるフィールドを検証
+	require.Contains(t, entry.Args, "trace_id")
+	require.Contains(t, entry.Args, "trace-123")
+
+	require.Contains(t, entry.Args, "request_id")
+	require.Contains(t, entry.Args, "req-456")
+
+	require.Contains(t, entry.Args, "method")
+	require.Contains(t, entry.Args, "/test.TestService/TestMethod")
+
+	require.Contains(t, entry.Args, "status_code")
+	require.Contains(t, entry.Args, "OK")
+
+	require.Contains(t, entry.Args, "duration_ms")
+	testutil.AssertDurationMsFieldExists(t, entry.Args)
+
+	require.Contains(t, entry.Args, "user_id")
+	require.Contains(t, entry.Args, "user-789")
+
+	require.Contains(t, entry.Args, "client_ip")
+	require.Contains(t, entry.Args, "192.168.1.1")
+}
+
+// TestLoggingInterceptor_ErrorLog は gRPC 呼び出しがエラーで終了したときに Error ログが出力されることを確認する
+func TestLoggingInterceptor_ErrorLog(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーとインターセプターを準備
+	mockLogger := testutil.NewMockLogger()
+	interceptor := grpcmw.LoggingInterceptor(mockLogger)
+
+	// context にメタデータを設定（LoggingHandler 内で使用される）
+	ctx := t.Context()
+	ctx = context.WithValue(ctx, middleware.ContextKeyTraceID, "trace-err")
+	ctx = context.WithValue(ctx, middleware.ContextKeyRequestID, "req-err")
+	ctx = context.WithValue(ctx, middleware.ContextKeyUserID, "user-err")
+	ctx = context.WithValue(ctx, middleware.ContextKeyClientIP, "10.0.0.1")
+
+	// エラーを返すハンドラーを定義
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return nil, status.Error(codes.Internal, "internal error")
+	}
+
+	// インターセプターを実行
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{
+		FullMethod: "/test.TestService/ErrorMethod",
+		Server:     nil,
+	}, handler)
+
+	// 結果を検証
+	require.Nil(t, resp)
+	require.Error(t, err)
+
+	// Error ログが1件記録されていることを確認
+	require.Len(t, mockLogger.Errors, 1)
+	entry := mockLogger.Errors[0]
+	require.Equal(t, "request failed", entry.Msg)
+	require.Error(t, entry.Err)
+	require.Contains(t, entry.Err.Error(), "internal error")
+
+	// ログに含まれるフィールドを検証
+	require.Contains(t, entry.Args, "trace_id")
+	require.Contains(t, entry.Args, "trace-err")
+
+	require.Contains(t, entry.Args, "request_id")
+	require.Contains(t, entry.Args, "req-err")
+
+	require.Contains(t, entry.Args, "method")
+	require.Contains(t, entry.Args, "/test.TestService/ErrorMethod")
+
+	require.Contains(t, entry.Args, "status_code")
+	require.Contains(t, entry.Args, "Internal")
+
+	require.Contains(t, entry.Args, "duration_ms")
+	testutil.AssertDurationMsFieldExists(t, entry.Args)
+
+	require.Contains(t, entry.Args, "user_id")
+	require.Contains(t, entry.Args, "user-err")
+
+	require.Contains(t, entry.Args, "client_ip")
+	require.Contains(t, entry.Args, "10.0.0.1")
+}

--- a/internal/app/middleware/logging.go
+++ b/internal/app/middleware/logging.go
@@ -1,0 +1,62 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+)
+
+type contextKey string
+
+const (
+	ContextKeyTraceID   contextKey = "trace_id"
+	ContextKeyRequestID contextKey = "request_id"
+	ContextKeyUserID    contextKey = "user_id"
+	ContextKeyClientIP  contextKey = "client_ip"
+)
+
+// LoggingHandler はリクエストの処理結果を共通形式でログ出力する関数
+func LoggingHandler(
+	ctx context.Context,
+	log logger.Logger,
+	method string,
+	statusCode string,
+	duration time.Duration,
+	err error,
+) {
+	// コンテキストから各種メタデータを取得（trace_id, request_id など）
+	traceID := GetStringFromContext(ctx, ContextKeyTraceID)
+	requestID := GetStringFromContext(ctx, ContextKeyRequestID)
+	userID := GetStringFromContext(ctx, ContextKeyUserID)
+	clientIP := GetStringFromContext(ctx, ContextKeyClientIP)
+
+	// ログ出力用のフィールドを構造化形式で整形
+	fields := []interface{}{
+		"trace_id", traceID,
+		"request_id", requestID,
+		"method", method,
+		"status_code", statusCode,
+		"duration_ms", duration.Milliseconds(),
+		"user_id", userID,
+		"client_ip", clientIP,
+	}
+
+	// 処理成功・失敗に応じてログレベルを切り替えて出力
+	if err != nil {
+		log.Error("request failed", err, fields...)
+	} else {
+		log.Info("request completed", fields...)
+	}
+}
+
+// GetStringFromContext は context から安全に string 型の値を取得するユーティリティ関数
+func GetStringFromContext(ctx context.Context, key interface{}) string {
+	if val := ctx.Value(key); val != nil {
+		if str, ok := val.(string); ok {
+			return str
+		}
+	}
+
+	return ""
+}

--- a/internal/app/middleware/logging_test.go
+++ b/internal/app/middleware/logging_test.go
@@ -1,0 +1,187 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/middleware"
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+)
+
+// 共通のエラーインスタンスを定義（err113回避のため）
+var errSomethingFailed = errors.New("something failed")
+
+// TestLoggingHandler_Info は LoggingHandler が正常系リクエストを Info ログとして記録することを確認する
+func TestLoggingHandler_Info(t *testing.T) {
+	t.Parallel()
+
+	mockLogger := testutil.NewMockLogger()
+
+	// コンテキストに全てのメタデータをセット
+	ctx := t.Context()
+	ctx = context.WithValue(ctx, middleware.ContextKeyTraceID, "trace-123")
+	ctx = context.WithValue(ctx, middleware.ContextKeyRequestID, "req-456")
+	ctx = context.WithValue(ctx, middleware.ContextKeyUserID, "user-789")
+	ctx = context.WithValue(ctx, middleware.ContextKeyClientIP, "192.168.1.1")
+
+	method := "GET /logs"
+	statusCode := "200 OK"
+	duration := 120 * time.Millisecond
+
+	// LoggingHandler を呼び出し
+	middleware.LoggingHandler(ctx, mockLogger, method, statusCode, duration, nil)
+
+	// Info ログが1件出力されていることを確認
+	require.Len(t, mockLogger.Infos, 1)
+	require.Empty(t, mockLogger.Errors)
+	require.Empty(t, mockLogger.Warns)
+
+	entry := mockLogger.Infos[0]
+	require.Equal(t, "request completed", entry.Msg)
+
+	// ログ出力内容に各フィールドが含まれていることを検証
+	require.Contains(t, entry.Args, "trace_id")
+	require.Contains(t, entry.Args, "trace-123")
+
+	require.Contains(t, entry.Args, "request_id")
+	require.Contains(t, entry.Args, "req-456")
+
+	require.Contains(t, entry.Args, "method")
+	require.Contains(t, entry.Args, method)
+
+	require.Contains(t, entry.Args, "status_code")
+	require.Contains(t, entry.Args, statusCode)
+
+	require.Contains(t, entry.Args, "duration_ms")
+	require.Contains(t, entry.Args, duration.Milliseconds())
+
+	require.Contains(t, entry.Args, "user_id")
+	require.Contains(t, entry.Args, "user-789")
+
+	require.Contains(t, entry.Args, "client_ip")
+	require.Contains(t, entry.Args, "192.168.1.1")
+}
+
+// TestLoggingHandler_Error は LoggingHandler がエラー発生時に Error ログとして記録することを確認する
+func TestLoggingHandler_Error(t *testing.T) {
+	t.Parallel()
+
+	mockLogger := testutil.NewMockLogger()
+
+	// すべてのメタデータを context にセット
+	ctx := t.Context()
+	ctx = context.WithValue(ctx, middleware.ContextKeyTraceID, "trace-error")
+	ctx = context.WithValue(ctx, middleware.ContextKeyRequestID, "req-error")
+	ctx = context.WithValue(ctx, middleware.ContextKeyUserID, "user-error")
+	ctx = context.WithValue(ctx, middleware.ContextKeyClientIP, "10.0.0.1")
+
+	method := "POST /fail"
+	statusCode := "500 Internal Server Error"
+	duration := 300 * time.Millisecond
+	err := errSomethingFailed
+
+	middleware.LoggingHandler(ctx, mockLogger, method, statusCode, duration, err)
+
+	require.Len(t, mockLogger.Errors, 1)
+	require.Empty(t, mockLogger.Infos)
+	require.Empty(t, mockLogger.Warns)
+
+	entry := mockLogger.Errors[0]
+	require.Equal(t, "request failed", entry.Msg)
+	require.Equal(t, err, entry.Err)
+
+	// ログ出力にすべてのフィールドが含まれていることを確認
+	require.Contains(t, entry.Args, "trace_id")
+	require.Contains(t, entry.Args, "trace-error")
+
+	require.Contains(t, entry.Args, "request_id")
+	require.Contains(t, entry.Args, "req-error")
+
+	require.Contains(t, entry.Args, "method")
+	require.Contains(t, entry.Args, method)
+
+	require.Contains(t, entry.Args, "status_code")
+	require.Contains(t, entry.Args, statusCode)
+
+	require.Contains(t, entry.Args, "duration_ms")
+	require.Contains(t, entry.Args, duration.Milliseconds())
+
+	require.Contains(t, entry.Args, "user_id")
+	require.Contains(t, entry.Args, "user-error")
+
+	require.Contains(t, entry.Args, "client_ip")
+	require.Contains(t, entry.Args, "10.0.0.1")
+}
+
+// TestLoggingHandler_EmptyFieldsAreIncluded は未設定のメタ情報も空文字でログに含まれることを確認する
+func TestLoggingHandler_EmptyFieldsAreIncluded(t *testing.T) {
+	t.Parallel()
+
+	mockLogger := testutil.NewMockLogger()
+
+	ctx := t.Context() // context に何もセットしない
+
+	method := "GET /logs"
+	statusCode := "200 OK"
+	duration := 150 * time.Millisecond
+
+	middleware.LoggingHandler(ctx, mockLogger, method, statusCode, duration, nil)
+
+	require.Len(t, mockLogger.Infos, 1)
+	entry := mockLogger.Infos[0]
+
+	require.Equal(t, "request completed", entry.Msg)
+
+	// 空文字として出力されるフィールドが含まれることを確認
+	require.Contains(t, entry.Args, "trace_id")
+	require.Contains(t, entry.Args, "")
+
+	require.Contains(t, entry.Args, "request_id")
+	require.Contains(t, entry.Args, "")
+
+	require.Contains(t, entry.Args, "method")
+	require.Contains(t, entry.Args, method)
+
+	require.Contains(t, entry.Args, "status_code")
+	require.Contains(t, entry.Args, statusCode)
+
+	require.Contains(t, entry.Args, "duration_ms")
+	require.Contains(t, entry.Args, duration.Milliseconds())
+
+	require.Contains(t, entry.Args, "user_id")
+	require.Contains(t, entry.Args, "")
+
+	require.Contains(t, entry.Args, "client_ip")
+	require.Contains(t, entry.Args, "")
+}
+
+// Test_GetStringFromContext_StringValueExists は文字列型の値が正しく取得できることを確認する
+func Test_GetStringFromContext_StringValueExists(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(t.Context(), middleware.ContextKeyTraceID, "abc123")
+	actual := middleware.GetStringFromContext(ctx, middleware.ContextKeyTraceID)
+	require.Equal(t, "abc123", actual)
+}
+
+// Test_GetStringFromContext_ValueIsNotString はコンテキストの値が string 以外の場合に空文字が返ることを確認する
+func Test_GetStringFromContext_ValueIsNotString(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(t.Context(), middleware.ContextKeyUserID, 123) // int型で格納
+	actual := middleware.GetStringFromContext(ctx, middleware.ContextKeyUserID)
+	require.Equal(t, "", actual)
+}
+
+// Test_GetStringFromContext_KeyNotFound は存在しないキーに対して空文字が返ることを確認する
+func Test_GetStringFromContext_KeyNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	actual := middleware.GetStringFromContext(ctx, "missing") // 不正なキー
+	require.Equal(t, "", actual)
+}

--- a/internal/app/middleware/rest/logging.go
+++ b/internal/app/middleware/rest/logging.go
@@ -1,0 +1,46 @@
+package restmw
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/middleware"
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+)
+
+// LoggingMiddleware は Echo 用の構造化リクエストログ出力ミドルウェア
+func LoggingMiddleware(log logger.Logger) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(echoCtx echo.Context) error {
+			// 処理開始時刻を記録（後で処理時間を測定するため）
+			start := time.Now()
+
+			// 実際のリクエスト処理（次のハンドラー）を実行
+			err := next(echoCtx)
+
+			// 処理完了までの経過時間を取得
+			duration := time.Since(start)
+
+			// HTTPメソッドとリクエストパスを組み合わせて、操作内容を表現（例: "GET /api/v1/users"）
+			method := echoCtx.Request().Method + " " + echoCtx.Path()
+
+			// レスポンスステータスコードを文字列で取得（例: "200", "404"）
+			statusCode := strconv.Itoa(echoCtx.Response().Status)
+
+			// 構造化ログ出力（trace_id や user_id は context にセットされている前提）
+			middleware.LoggingHandler(
+				echoCtx.Request().Context(),
+				log,
+				method,
+				statusCode,
+				duration,
+				err,
+			)
+
+			// 次のハンドラーの結果をそのまま返却
+			return err
+		}
+	}
+}

--- a/internal/app/middleware/rest/logging.go
+++ b/internal/app/middleware/rest/logging.go
@@ -29,7 +29,8 @@ func LoggingMiddleware(log logger.Logger) echo.MiddlewareFunc {
 			// レスポンスステータスコードを文字列で取得（例: "200", "404"）
 			statusCode := strconv.Itoa(echoCtx.Response().Status)
 
-			// 構造化ログ出力（trace_id や user_id は context にセットされている前提）
+			// LoggingHandler を使って構造化ログを出力
+			// trace_id や user_id などは context から LoggingHandler 側で取得
 			middleware.LoggingHandler(
 				echoCtx.Request().Context(),
 				log,
@@ -39,7 +40,7 @@ func LoggingMiddleware(log logger.Logger) echo.MiddlewareFunc {
 				err,
 			)
 
-			// 次のハンドラーの結果をそのまま返却
+			// ハンドラの結果をそのまま返す
 			return err
 		}
 	}

--- a/internal/app/middleware/rest/logging_test.go
+++ b/internal/app/middleware/rest/logging_test.go
@@ -1,0 +1,136 @@
+package restmw_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/middleware"
+	restmw "github.com/KeitaShimura/logs-collector-api/internal/app/middleware/rest"
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+)
+
+// TestLoggingMiddleware_InfoLogEmitted は正常系リクエストで Info ログが出力されることを確認する
+func TestLoggingMiddleware_InfoLogEmitted(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーを使ってログ出力を確認
+	mockLogger := testutil.NewMockLogger()
+
+	echoServer := echo.New()
+	echoServer.Use(restmw.LoggingMiddleware(mockLogger))
+
+	// エンドポイントを設定
+	echoServer.GET("/hello", func(echoCtx echo.Context) error {
+		// 必要な context メタデータを埋め込む
+		ctx := echoCtx.Request().Context()
+		ctx = context.WithValue(ctx, middleware.ContextKeyTraceID, "trace-xyz")
+		ctx = context.WithValue(ctx, middleware.ContextKeyRequestID, "req-123")
+		ctx = context.WithValue(ctx, middleware.ContextKeyUserID, "user-456")
+		ctx = context.WithValue(ctx, middleware.ContextKeyClientIP, "127.0.0.1")
+		echoCtx.SetRequest(echoCtx.Request().WithContext(ctx))
+
+		return echoCtx.String(http.StatusOK, "ok")
+	})
+
+	// テストリクエストを実行
+	req := httptest.NewRequest(http.MethodGet, "/hello", nil)
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// ステータスコード検証
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// ログ出力検証
+	require.Len(t, mockLogger.Infos, 1)
+	entry := mockLogger.Infos[0]
+	require.Equal(t, "request completed", entry.Msg)
+
+	// 含まれるフィールドを確認（構造化ログ）
+	require.Contains(t, entry.Args, "trace_id")
+	require.Contains(t, entry.Args, "trace-xyz")
+
+	require.Contains(t, entry.Args, "request_id")
+	require.Contains(t, entry.Args, "req-123")
+
+	require.Contains(t, entry.Args, "method")
+	require.Contains(t, entry.Args, "GET /hello")
+
+	require.Contains(t, entry.Args, "status_code")
+	require.Contains(t, entry.Args, "200")
+
+	require.Contains(t, entry.Args, "duration_ms")
+	testutil.AssertDurationMsFieldExists(t, entry.Args)
+
+	require.Contains(t, entry.Args, "user_id")
+	require.Contains(t, entry.Args, "user-456")
+
+	require.Contains(t, entry.Args, "client_ip")
+	require.Contains(t, entry.Args, "127.0.0.1")
+}
+
+// TestLoggingMiddleware_ErrorLogEmitted は異常系リクエストで Error ログが出力されることを確認する
+func TestLoggingMiddleware_ErrorLogEmitted(t *testing.T) {
+	t.Parallel()
+
+	// モックロガーを準備
+	mockLogger := testutil.NewMockLogger()
+
+	echoServer := echo.New()
+	echoServer.Use(restmw.LoggingMiddleware(mockLogger))
+
+	// 異常系エンドポイント（明示的にエラーを返す）
+	echoServer.GET("/error", func(echoCtx echo.Context) error {
+		ctx := echoCtx.Request().Context()
+		ctx = context.WithValue(ctx, middleware.ContextKeyTraceID, "trace-err")
+		ctx = context.WithValue(ctx, middleware.ContextKeyRequestID, "req-err")
+		ctx = context.WithValue(ctx, middleware.ContextKeyUserID, "user-err")
+		ctx = context.WithValue(ctx, middleware.ContextKeyClientIP, "192.168.1.100")
+		echoCtx.SetRequest(echoCtx.Request().WithContext(ctx))
+
+		echoCtx.Response().WriteHeader(http.StatusInternalServerError)
+
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal failure")
+	})
+
+	// テストリクエスト送信
+	req := httptest.NewRequest(http.MethodGet, "/error", nil)
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// ステータス確認
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// ログ出力（Error）を検証
+	require.Len(t, mockLogger.Errors, 1)
+	entry := mockLogger.Errors[0]
+	require.Equal(t, "request failed", entry.Msg)
+	require.Error(t, entry.Err)
+	require.Contains(t, entry.Err.Error(), "internal failure")
+
+	// 含まれるフィールドを確認
+	require.Contains(t, entry.Args, "trace_id")
+	require.Contains(t, entry.Args, "trace-err")
+
+	require.Contains(t, entry.Args, "request_id")
+	require.Contains(t, entry.Args, "req-err")
+
+	require.Contains(t, entry.Args, "method")
+	require.Contains(t, entry.Args, "GET /error")
+
+	require.Contains(t, entry.Args, "status_code")
+	require.Contains(t, entry.Args, "500")
+
+	require.Contains(t, entry.Args, "duration_ms")
+	testutil.AssertDurationMsFieldExists(t, entry.Args)
+
+	require.Contains(t, entry.Args, "user_id")
+	require.Contains(t, entry.Args, "user-err")
+
+	require.Contains(t, entry.Args, "client_ip")
+	require.Contains(t, entry.Args, "192.168.1.100")
+}

--- a/internal/app/middleware/rest/recovery.go
+++ b/internal/app/middleware/rest/recovery.go
@@ -12,18 +12,18 @@ import (
 // RecoveryMiddleware は Echo 用の panic リカバリー用ミドルウェア
 func RecoveryMiddleware(log logger.Logger) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(ctx echo.Context) error {
+		return func(echoCtx echo.Context) error {
 			defer func() {
 				if r := recover(); r != nil {
 					// 共通のリカバリーロガーを呼び出し、panic 内容を記録
 					middleware.RecoveryHandler(log, map[string]interface{}{
 						"panic":  r,
-						"path":   ctx.Request().URL.Path,
-						"method": ctx.Request().Method,
+						"path":   echoCtx.Request().URL.Path,
+						"method": echoCtx.Request().Method,
 					})
 
 					// クライアントに HTTP 500 を返却
-					if err := ctx.JSON(http.StatusInternalServerError, map[string]string{
+					if err := echoCtx.JSON(http.StatusInternalServerError, map[string]string{
 						"error": "internal server error",
 					}); err != nil {
 						log.Error("failed to send error response", err)
@@ -32,7 +32,7 @@ func RecoveryMiddleware(log logger.Logger) echo.MiddlewareFunc {
 			}()
 
 			// 通常のハンドラー処理を実行
-			return next(ctx)
+			return next(echoCtx)
 		}
 	}
 }

--- a/internal/app/middleware/rest/recovery_test.go
+++ b/internal/app/middleware/rest/recovery_test.go
@@ -26,8 +26,8 @@ func TestRecoveryMiddleware_NormalFlow(t *testing.T) {
 	echoServer.Use(restmw.RecoveryMiddleware(mockLogger))
 
 	// 正常に "OK" を返すハンドラー
-	echoServer.GET("/test", func(c echo.Context) error {
-		return c.String(http.StatusOK, "OK")
+	echoServer.GET("/test", func(echoCtx echo.Context) error {
+		return echoCtx.String(http.StatusOK, "OK")
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)

--- a/internal/testutil/log_assert.go
+++ b/internal/testutil/log_assert.go
@@ -1,0 +1,38 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// AssertDurationMsFieldExists は duration_ms フィールドが存在し、int64 型かつ 0 以上であることを検証する
+func AssertDurationMsFieldExists(t *testing.T, args []any) {
+	t.Helper()
+
+	var durationFound bool
+
+	// 引数 args を "キー → 値" のペアとして順番に確認する
+	for i := 0; i < len(args)-1; i += 2 {
+		key := args[i]
+
+		// duration_ms キーを検出した場合にのみ検証を実施
+		if key == "duration_ms" {
+			val := args[i+1]
+
+			// 値が int64 型であることを検証
+			ms, ok := val.(int64)
+			require.True(t, ok, "duration_ms value should be int64")
+
+			// 値が 0 以上であることを検証
+			require.GreaterOrEqual(t, ms, int64(0))
+
+			durationFound = true
+
+			break
+		}
+	}
+
+	// duration_ms キーが存在していたことを検証
+	require.True(t, durationFound, "duration_ms field should be present in log")
+}

--- a/internal/testutil/mock_logger.go
+++ b/internal/testutil/mock_logger.go
@@ -7,11 +7,13 @@ import (
 // LogEntry はモックロガーで記録されたログ情報
 type LogEntry struct {
 	Msg  string
+	Err  error
 	Args []any
 }
 
 // MockLogger は Logger を模倣するモック構造体
 type MockLogger struct {
+	Debugs []LogEntry
 	Infos  []LogEntry
 	Warns  []LogEntry
 	Errors []LogEntry
@@ -22,17 +24,29 @@ func (m *MockLogger) SetLevel(_ slog.Level) {}
 
 // Debug はデバッグ用の詳細ログを出力する
 func (m *MockLogger) Debug(msg string, args ...any) {
-	m.Infos = append(m.Infos, LogEntry{Msg: msg, Args: args})
+	m.Debugs = append(m.Debugs, LogEntry{
+		Msg:  msg,
+		Err:  nil,
+		Args: args,
+	})
 }
 
 // Info は情報ログを出力する
 func (m *MockLogger) Info(msg string, args ...any) {
-	m.Infos = append(m.Infos, LogEntry{Msg: msg, Args: args})
+	m.Infos = append(m.Infos, LogEntry{
+		Msg:  msg,
+		Err:  nil,
+		Args: args,
+	})
 }
 
 // Warn は警告ログを出力する
 func (m *MockLogger) Warn(msg string, args ...any) {
-	m.Warns = append(m.Warns, LogEntry{Msg: msg, Args: args})
+	m.Warns = append(m.Warns, LogEntry{
+		Msg:  msg,
+		Err:  nil,
+		Args: args,
+	})
 }
 
 // Error はエラーログを出力する（nil エラーも考慮）
@@ -41,12 +55,17 @@ func (m *MockLogger) Error(msg string, err error, args ...any) {
 		args = append(args, slog.String("error", err.Error()))
 	}
 
-	m.Errors = append(m.Errors, LogEntry{Msg: msg, Args: args})
+	m.Errors = append(m.Errors, LogEntry{
+		Msg:  msg,
+		Err:  err,
+		Args: args,
+	})
 }
 
 // NewMockLogger はモックロガーを初期化して返す
 func NewMockLogger() *MockLogger {
 	return &MockLogger{
+		Debugs: []LogEntry{},
 		Infos:  []LogEntry{},
 		Warns:  []LogEntry{},
 		Errors: []LogEntry{},


### PR DESCRIPTION
# 概要

このPRでは、**REST（Echo）および gRPC 双方に対応した共通の構造化ログ出力ミドルウェア**を導入し、リクエスト処理の可観測性と障害解析の効率化を図りました。

---

## 🔨 主な実装内容

- **共通の `LoggingHandler` 実装（`middleware` パッケージ）**
  - コンテキストから取得した `trace_id`、`request_id`、`user_id`、`client_ip` などのメタデータとともに、
    リクエストのメソッド、ステータスコード、処理時間を構造化ログとして出力。

- **REST用 `LoggingMiddleware` 実装（`restmw` パッケージ）**
  - Echo フレームワーク用のミドルウェア。
  - リクエストの開始時刻を記録し、処理後に経過時間を計測。
  - HTTPメソッドとリクエストパスを組み合わせた操作内容、ステータスコード、処理時間を `LoggingHandler` に渡してログ出力。

- **gRPC用 `LoggingInterceptor` 実装（`grpcmw` パッケージ）**
  - gRPC サーバー用の Unary インターセプター。
  - リクエストの開始時刻を記録し、処理後に経過時間を計測。
  - 呼び出された gRPC メソッドの完全修飾名（`info.FullMethod`）、ステータスコード、処理時間を `LoggingHandler` に渡してログ出力。

---

## 🧪 追加テスト

- **`LoggingHandler` のユニットテスト**
  - ログに含まれる各フィールド（`trace_id`、`request_id`、`user_id`、`client_ip`、`method`、`status_code`、`duration_ms`）の正確性を検証。
  - エラー発生時のログ出力内容を検証。

- **REST用 `LoggingMiddleware` のテスト**
  - 正常系：リクエスト処理が成功した場合のログ出力を検証。
  - 異常系：ハンドラー内でエラーが発生した場合のログ出力を検証。

- **gRPC用 `LoggingInterceptor` のテスト**
  - 正常系：リクエスト処理が成功した場合のログ出力を検証。
  - 異常系：ハンドラー内でエラーが発生した場合のログ出力を検証。

---

## 🎯 目的と効果

- REST / gRPC 双方のサーバーでリクエスト処理の詳細なログを一貫した形式で出力。
- 障害発生時にスタック情報やリクエストメタデータを構造化ログとして記録し、迅速な原因特定と対応を可能に。
- 開発・運用時の可観測性を向上させ、システムの信頼性を強化。