### PR TITLE
feat: add timeout and server startup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,14 +1,231 @@
 package main
 
 import (
-	"log"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	_ "github.com/lib/pq"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
+	appgrpc "github.com/KeitaShimura/logs-collector-api/internal/app/handler/grpc"
+	"github.com/KeitaShimura/logs-collector-api/internal/app/handler/rest"
+	grpcmw "github.com/KeitaShimura/logs-collector-api/internal/app/middleware/grpc"
+	"github.com/KeitaShimura/logs-collector-api/internal/app/usecase"
+	"github.com/KeitaShimura/logs-collector-api/internal/config"
+	dbpkg "github.com/KeitaShimura/logs-collector-api/internal/infra/db"
+	"github.com/KeitaShimura/logs-collector-api/internal/infra/queue"
+	"github.com/KeitaShimura/logs-collector-api/internal/infra/search"
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+	"github.com/KeitaShimura/logs-collector-api/internal/pkg/server"
+	pb "github.com/KeitaShimura/logs-collector-protos/go/logs/v1"
 )
 
 func main() {
-	log.Println("Application has started")
+	// アプリケーションの起動処理を実行し、エラーがあれば終了コード1で終了
+	if err := run(); err != nil {
+		os.Exit(1)
+	}
+}
 
-	// Some processing
-	log.Println("Processing...")
+// run はアプリケーションの初期化と各種サービスの起動を行います。
+func run() error {
+	// 暫定ロガーで最低限のログを出力
+	tmpLogger := setupLogger("INFO")
 
-	log.Println("Application has finished")
+	// 設定読み込み（ログレベルを含む）
+	cfg, err := config.NewConfig(tmpLogger)
+	if err != nil {
+		tmpLogger.Error("Failed to load configuration", err)
+
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	// 正式なログレベルで再設定
+	log := setupLogger(cfg.LogLevel)
+	log.Info("Application startup initiated")
+
+	log.Info("Configuration loaded successfully", "DBHost", cfg.DBHost, "DBPort", cfg.DBPort)
+
+	// PostgreSQLとの接続を確立
+	dbConn, err := connectDatabase(cfg, log)
+	if err != nil {
+		log.Error("Failed to establish database connection", err)
+
+		return fmt.Errorf("failed to establish database connection: %w", err)
+	}
+
+	defer dbConn.Close()
+	log.Info("Database connection established")
+
+	// SQLBoilerの executor を作成してリポジトリに注入
+	exec := boil.ContextExecutor(dbConn)
+	logRepo := dbpkg.NewLogRepository(exec, log)
+
+	// NATS Producer を初期化（設定から読み込む）
+	natsProducer, err := queue.NewProducer(cfg.NATSURL, log)
+	if err != nil {
+		log.Error("Failed to initialize NATS Producer", err)
+
+		return fmt.Errorf("failed to initialize NATS Producer: %w", err)
+	}
+
+	// Elasticsearch クライアントを指定URLで初期化
+	//
+	//nolint:exhaustruct // 使用するフィールドのみ明示的に指定
+	esCfg := elasticsearch.Config{
+		Addresses: []string{cfg.ElasticsearchURL},
+	}
+
+	esClient, err := elasticsearch.NewClient(esCfg)
+	if err != nil {
+		log.Error("Failed to initialize Elasticsearch client", err)
+
+		return fmt.Errorf("failed to initialize Elasticsearch client: %w", err)
+	}
+
+	// Elasticsearch ラッパーの生成
+	esSearcher := search.NewLogSearcher(esClient, log)
+	// ユースケース層の初期化
+	logUseCase := usecase.NewLogUseCase(logRepo, natsProducer, esSearcher, log)
+	// gRPC呼び出しのタイムアウト（設定値[秒]から time.Duration に変換）
+	grpcTimeout := time.Duration(cfg.GRPCTimeoutSec) * time.Second
+	// RESTサーバーのシャットダウン猶予時間（設定値[秒]から time.Duration に変換）
+	shutdownTimeout := time.Duration(cfg.ShutdownTimeoutSec) * time.Second
+
+	// gRPC と REST サーバーを非同期で起動（ポートは cfg から取得）
+	go startGRPCServer(logUseCase, log, cfg, grpcTimeout)
+	go startRESTServer(logUseCase, log, cfg, shutdownTimeout)
+
+	// 終了シグナル（Ctrl+C, SIGTERM）を受け取るまで待機
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	<-sigCh
+
+	log.Info("Shutting down both servers gracefully")
+
+	return nil
+}
+
+// setupLogger は構造化ロガーを初期化する
+//
+//nolint:ireturn // クリーンアーキテクチャのため命名を維持
+func setupLogger(logLevel string) logger.Logger {
+	return logger.NewLogger(
+		logger.WithLevel(logger.ParseLevel(logLevel)),
+		logger.WithWriter(os.Stdout),
+	)
+}
+
+// connectDatabase は指定された設定をもとにデータベースへ接続します。
+func connectDatabase(cfg *config.Config, log logger.Logger) (*sql.DB, error) {
+	hostPort := net.JoinHostPort(cfg.DBHost, cfg.DBPort)
+
+	// PostgreSQL接続文字列（DSN）を構築
+	dsn := fmt.Sprintf(
+		"postgres://%s:%s@%s/%s?sslmode=%s&TimeZone=%s",
+		cfg.DBUser, cfg.DBPassword, hostPort, cfg.DBName, cfg.DBSSLMode, cfg.DBTimeZone,
+	)
+
+	// DB接続を試みる
+	dbConn, err := sql.Open("postgres", dsn)
+	if err != nil {
+		log.Error("Database connection failed", err, "dsn", dsn)
+
+		return nil, fmt.Errorf("sql.Open failed: %w", err)
+	}
+
+	return dbConn, nil
+}
+
+// startGRPCServer はgRPCサーバーを初期化し、指定ポートで起動します。
+func startGRPCServer(
+	logUseCase usecase.LogUseCase,
+	log logger.Logger,
+	cfg *config.Config,
+	grpcTimeout time.Duration,
+) *grpc.Server {
+	logHandler := appgrpc.NewLogHandler(logUseCase, log)
+
+	// 各種 gRPC ミドルウェアを適用
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(
+			grpcmw.LoggingInterceptor(log),
+			grpcmw.TimeoutInterceptor(grpcTimeout, log),
+			grpcmw.RecoveryInterceptor(log),
+			grpcmw.ValidationInterceptor(log),
+		),
+	)
+
+	// サービス登録とリフレクション設定
+	pb.RegisterLogServiceServer(grpcServer, logHandler)
+	reflection.Register(grpcServer)
+
+	// アドレス構築（例: 0.0.0.0:50051）
+	addr := net.JoinHostPort(cfg.GRPCBindAddr, cfg.GRPCPort)
+
+	// ポートバインド（設定に応じて localhost または全体に公開）
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Error("Failed to bind gRPC server to address", err, "address", addr)
+		os.Exit(1)
+	}
+
+	// サーバー起動（非同期）
+	go func() {
+		log.Info("gRPC server started", "address", addr)
+
+		if err := grpcServer.Serve(listener); err != nil {
+			log.Error("gRPC server encountered an error", err)
+		}
+	}()
+
+	return grpcServer
+}
+
+// startRESTServer はREST APIサーバーを起動し、SIGINT/SIGTERM を受けて優雅に終了します。
+func startRESTServer(
+	logUseCase usecase.LogUseCase,
+	log logger.Logger,
+	cfg *config.Config,
+	shutdownTimeout time.Duration,
+) {
+	logHandler := rest.NewLogHandler(logUseCase, log)
+
+	// Echo サーバーインスタンスの作成
+	restTimeout := time.Duration(cfg.RESTTimeoutSec) * time.Second
+	echoServer := server.NewRouter(logHandler, log, restTimeout)
+	addr := net.JoinHostPort(cfg.RESTBindAddr, cfg.RESTPort)
+	log.Info("Starting REST server", "address", addr)
+
+	// Echo サーバーの起動（非同期）
+	go func() {
+		if err := echoServer.Start(addr); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error("REST server failed", err)
+		}
+	}()
+
+	// シャットダウン処理（SIGINT/SIGTERM 受信時）
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		<-sigCh
+
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+
+		if err := echoServer.Shutdown(ctx); err != nil {
+			log.Error("Failed to shutdown REST server gracefully", err)
+		}
+	}()
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/caarlos0/env/v11"
 
@@ -43,9 +42,10 @@ type Config struct {
 	RESTBindAddr string `env:"REST_BIND_ADDR" envDefault:"0.0.0.0"`
 
 	// --- タイムアウト/ログ設定 ---
-	GRPCTimeout     time.Duration `env:"GRPC_TIMEOUT"       envDefault:"2s"`
-	ShutdownTimeout time.Duration `env:"SHUTDOWN_TIMEOUT"   envDefault:"10s"`
-	LogLevel        string        `env:"LOG_LEVEL"          envDefault:"INFO"`
+	GRPCTimeoutSec     int    `env:"GRPC_TIMEOUT_SEC"     envDefault:"2"`
+	RESTTimeoutSec     int    `env:"REST_TIMEOUT_SEC"     envDefault:"3"`
+	ShutdownTimeoutSec int    `env:"SHUTDOWN_TIMEOUT_SEC" envDefault:"10"`
+	LogLevel           string `env:"LOG_LEVEL"            envDefault:"INFO"`
 }
 
 // NewConfig は環境変数から設定値を読み込み、Config 構造体を返す
@@ -61,15 +61,19 @@ func NewConfig(log logger.Logger) (*Config, error) {
 	if cfg.DBHost == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBHostRequired)
 	}
+
 	if cfg.DBPort == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBPortRequired)
 	}
+
 	if cfg.DBName == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBNameRequired)
 	}
+
 	if cfg.DBUser == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBUserRequired)
 	}
+
 	if cfg.DBPassword == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBPasswordRequired)
 	}
@@ -79,6 +83,7 @@ func NewConfig(log logger.Logger) (*Config, error) {
 		"DBHost", cfg.DBHost,
 		"DBPort", cfg.DBPort,
 		"DBName", cfg.DBName,
+		"DBUser", cfg.DBUser,
 		"DBSSLMode", cfg.DBSSLMode,
 		"DBTimeZone", cfg.DBTimeZone,
 		"NATSURL", cfg.NATSURL,
@@ -87,8 +92,9 @@ func NewConfig(log logger.Logger) (*Config, error) {
 		"GRPCBindAddr", cfg.GRPCBindAddr,
 		"RESTPort", cfg.RESTPort,
 		"RESTBindAddr", cfg.RESTBindAddr,
-		"GRPCTimeout", cfg.GRPCTimeout.String(),
-		"ShutdownTimeout", cfg.ShutdownTimeout.String(),
+		"GRPCTimeout", cfg.GRPCTimeoutSec,
+		"RESTTimeoutSec", cfg.RESTTimeoutSec,
+		"ShutdownTimeout", cfg.ShutdownTimeoutSec,
 		"LogLevel", cfg.LogLevel,
 	)
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -36,8 +36,9 @@ type Config struct {
 	ElasticsearchURL string `env:"ELASTICSEARCH_URL" envDefault:"http://localhost:9200"`
 
 	// --- サーバーポート設定 ---
-	GRPCPort string `env:"GRPC_PORT" envDefault:"50051"`
-	RESTPort string `env:"REST_PORT" envDefault:"8080"`
+	GRPCPort     string `env:"GRPC_PORT"      envDefault:"50051"`
+	RESTPort     string `env:"REST_PORT"      envDefault:"8080"`
+	GRPCBindAddr string `env:"GRPC_BIND_ADDR" envDefault:"0.0.0.0"` // 柔軟なバインド対応（localhost or 全体）
 }
 
 // NewConfig は環境変数から設定値を読み込み、Config 構造体を返す
@@ -80,6 +81,7 @@ func NewConfig(log logger.Logger) (*Config, error) {
 		"NATSURL", cfg.NATSURL,
 		"ElasticsearchURL", cfg.ElasticsearchURL,
 		"GRPCPort", cfg.GRPCPort,
+		"GRPCBindAddr", cfg.GRPCBindAddr,
 		"RESTPort", cfg.RESTPort,
 	)
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -9,7 +9,7 @@ import (
 	"github.com/KeitaShimura/logs-collector-api/internal/logger"
 )
 
-// 共通エラー定義（DB用）
+// 共通エラー定義
 var (
 	errDBHostRequired     = errors.New("DB_HOST is required but not set")
 	errDBPortRequired     = errors.New("DB_PORT is required but not set")

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/caarlos0/env/v11"
 
@@ -35,10 +36,16 @@ type Config struct {
 	// --- Elasticsearch 設定 ---
 	ElasticsearchURL string `env:"ELASTICSEARCH_URL" envDefault:"http://localhost:9200"`
 
-	// --- サーバーポート設定 ---
+	// --- サーバーポート/バインド設定 ---
 	GRPCPort     string `env:"GRPC_PORT"      envDefault:"50051"`
+	GRPCBindAddr string `env:"GRPC_BIND_ADDR" envDefault:"0.0.0.0"`
 	RESTPort     string `env:"REST_PORT"      envDefault:"8080"`
-	GRPCBindAddr string `env:"GRPC_BIND_ADDR" envDefault:"0.0.0.0"` // 柔軟なバインド対応（localhost or 全体）
+	RESTBindAddr string `env:"REST_BIND_ADDR" envDefault:"0.0.0.0"`
+
+	// --- タイムアウト/ログ設定 ---
+	GRPCTimeout     time.Duration `env:"GRPC_TIMEOUT"       envDefault:"2s"`
+	ShutdownTimeout time.Duration `env:"SHUTDOWN_TIMEOUT"   envDefault:"10s"`
+	LogLevel        string        `env:"LOG_LEVEL"          envDefault:"INFO"`
 }
 
 // NewConfig は環境変数から設定値を読み込み、Config 構造体を返す
@@ -50,28 +57,24 @@ func NewConfig(log logger.Logger) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse env config: %w", err)
 	}
 
-	// --- 必須項目チェック（明示的に required:"true" の再確認） ---
+	// --- 必須項目チェック ---
 	if cfg.DBHost == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBHostRequired)
 	}
-
 	if cfg.DBPort == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBPortRequired)
 	}
-
 	if cfg.DBName == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBNameRequired)
 	}
-
 	if cfg.DBUser == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBUserRequired)
 	}
-
 	if cfg.DBPassword == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBPasswordRequired)
 	}
 
-	// ログ出力（必要な情報のみ出力、パスワードなどは含めない）
+	// ログ出力（パスワードは出さない）
 	log.Info("Configuration loaded successfully",
 		"DBHost", cfg.DBHost,
 		"DBPort", cfg.DBPort,
@@ -83,6 +86,10 @@ func NewConfig(log logger.Logger) (*Config, error) {
 		"GRPCPort", cfg.GRPCPort,
 		"GRPCBindAddr", cfg.GRPCBindAddr,
 		"RESTPort", cfg.RESTPort,
+		"RESTBindAddr", cfg.RESTBindAddr,
+		"GRPCTimeout", cfg.GRPCTimeout.String(),
+		"ShutdownTimeout", cfg.ShutdownTimeout.String(),
+		"LogLevel", cfg.LogLevel,
 	)
 
 	return &cfg, nil

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -9,7 +9,7 @@ import (
 	"github.com/KeitaShimura/logs-collector-api/internal/logger"
 )
 
-// 共通エラー定義
+// 共通エラー定義（DB用）
 var (
 	errDBHostRequired     = errors.New("DB_HOST is required but not set")
 	errDBPortRequired     = errors.New("DB_PORT is required but not set")
@@ -20,6 +20,7 @@ var (
 
 // Config は環境変数から取得する設定情報を保持する構造体
 type Config struct {
+	// --- Database 設定 ---
 	DBHost     string `env:"DB_HOST"     required:"true"`
 	DBPort     string `env:"DB_PORT"     required:"true"`
 	DBName     string `env:"DB_NAME"     required:"true"`
@@ -27,17 +28,28 @@ type Config struct {
 	DBPassword string `env:"DB_PASS"     required:"true"`
 	DBSSLMode  string `env:"DB_SSLMODE"  envDefault:"disable"`
 	DBTimeZone string `env:"DB_TIMEZONE" envDefault:"Asia/Tokyo"`
+
+	// --- NATS 設定 ---
+	NATSURL string `env:"NATS_URL" envDefault:"nats://localhost:4222"`
+
+	// --- Elasticsearch 設定 ---
+	ElasticsearchURL string `env:"ELASTICSEARCH_URL" envDefault:"http://localhost:9200"`
+
+	// --- サーバーポート設定 ---
+	GRPCPort string `env:"GRPC_PORT" envDefault:"50051"`
+	RESTPort string `env:"REST_PORT" envDefault:"8080"`
 }
 
 // NewConfig は環境変数から設定値を読み込み、Config 構造体を返す
 func NewConfig(log logger.Logger) (*Config, error) {
 	var cfg Config
 
+	// 環境変数から構造体にマッピング
 	if err := env.Parse(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse env config: %w", err)
 	}
 
-	// --- 必須項目チェック ---
+	// --- 必須項目チェック（明示的に required:"true" の再確認） ---
 	if cfg.DBHost == "" {
 		return nil, fmt.Errorf("validation error: %w", errDBHostRequired)
 	}
@@ -58,12 +70,17 @@ func NewConfig(log logger.Logger) (*Config, error) {
 		return nil, fmt.Errorf("validation error: %w", errDBPasswordRequired)
 	}
 
+	// ログ出力（必要な情報のみ出力、パスワードなどは含めない）
 	log.Info("Configuration loaded successfully",
 		"DBHost", cfg.DBHost,
 		"DBPort", cfg.DBPort,
 		"DBName", cfg.DBName,
 		"DBSSLMode", cfg.DBSSLMode,
 		"DBTimeZone", cfg.DBTimeZone,
+		"NATSURL", cfg.NATSURL,
+		"ElasticsearchURL", cfg.ElasticsearchURL,
+		"GRPCPort", cfg.GRPCPort,
+		"RESTPort", cfg.RESTPort,
 	)
 
 	return &cfg, nil

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -117,6 +117,9 @@ func (logger *LoggerImpl) Error(msg string, err error, args ...any) {
 	logger.slog.Error(msg, args...)
 }
 
+// ParseLevel は文字列で指定されたログレベルを slog.Level 型に変換して返す。
+// 対応しているレベルは "DEBUG"、"WARN"、"ERROR" で、
+// その他の値はデフォルトで LevelInfo を返す。
 func ParseLevel(level string) slog.Level {
 	switch level {
 	case "DEBUG":

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -116,3 +116,16 @@ func (logger *LoggerImpl) Error(msg string, err error, args ...any) {
 
 	logger.slog.Error(msg, args...)
 }
+
+func ParseLevel(level string) slog.Level {
+	switch level {
+	case "DEBUG":
+		return LevelDebug
+	case "WARN":
+		return LevelWarn
+	case "ERROR":
+		return LevelError
+	default:
+		return LevelInfo
+	}
+}

--- a/internal/pkg/server/router.go
+++ b/internal/pkg/server/router.go
@@ -14,10 +14,8 @@ import (
 	customValidator "github.com/KeitaShimura/logs-collector-api/internal/pkg/validator"
 )
 
-const restTimeout = 3 * time.Second
-
 // NewRouter は Echo サーバーのルーターを初期化し、エンドポイントを登録する
-func NewRouter(logHandler *rest.LogHandler, logger logger.Logger) *echo.Echo {
+func NewRouter(logHandler *rest.LogHandler, logger logger.Logger, restTimeout time.Duration) *echo.Echo {
 	// Echo インスタンスを作成
 	echoServer := echo.New()
 

--- a/internal/pkg/server/router.go
+++ b/internal/pkg/server/router.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"time"
+
 	"github.com/labstack/echo/v4"
 	echoSwagger "github.com/swaggo/echo-swagger"
 
@@ -12,6 +14,8 @@ import (
 	customValidator "github.com/KeitaShimura/logs-collector-api/internal/pkg/validator"
 )
 
+const restTimeout = 3 * time.Second
+
 // NewRouter は Echo サーバーのルーターを初期化し、エンドポイントを登録する
 func NewRouter(logHandler *rest.LogHandler, logger logger.Logger) *echo.Echo {
 	// Echo インスタンスを作成
@@ -19,6 +23,7 @@ func NewRouter(logHandler *rest.LogHandler, logger logger.Logger) *echo.Echo {
 
 	// 共通ミドルウェア
 	echoServer.Use(restmw.LoggingMiddleware(logger))
+	echoServer.Use(restmw.TimeoutMiddleware(restTimeout, logger))
 	echoServer.Use(restmw.RecoveryMiddleware(logger))
 
 	// カスタムバリデーターを設定（Echo のバリデーション用）

--- a/internal/pkg/server/router_test.go
+++ b/internal/pkg/server/router_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/mock"
@@ -23,10 +24,12 @@ import (
 func TestSwaggerRoute(t *testing.T) {
 	t.Parallel()
 
+	restTimeout := 3 * time.Second // テスト用の REST タイムアウト
+
 	// モックのユースケースとロガーを準備
 	mockUC := new(appmock.LogUseCase)
 	mockLogger := appmock.NewLogger()
-	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger), mockLogger)
+	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger), mockLogger, restTimeout)
 
 	// Swaggerドキュメント用のGETリクエストを作成
 	req := httptest.NewRequest(http.MethodGet, "/swagger/index.html", nil)
@@ -43,12 +46,14 @@ func TestSwaggerRoute(t *testing.T) {
 func TestPostLogsRoute_Success(t *testing.T) {
 	t.Parallel()
 
+	restTimeout := 3 * time.Second // テスト用の REST タイムアウト
+
 	// モックユースケースのSendLogを成功レスポンスに設定
 	mockUC := new(appmock.LogUseCase)
 	mockUC.On("SendLog", mock.Anything, mock.AnythingOfType("*model.Log")).Return(nil)
 
 	mockLogger := appmock.NewLogger()
-	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger), mockLogger)
+	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger), mockLogger, restTimeout)
 
 	// テスト用のPOSTリクエストボディを作成
 	reqBody := &pb.SendLogRequest{
@@ -92,10 +97,12 @@ func TestPostLogsRoute_Success(t *testing.T) {
 func TestPostLogsRoute_NotFound(t *testing.T) {
 	t.Parallel()
 
+	restTimeout := 3 * time.Second // テスト用の REST タイムアウト
+
 	// モックのユースケースとロガーを準備
 	mockUC := new(appmock.LogUseCase)
 	mockLogger := appmock.NewLogger()
-	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger), mockLogger)
+	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger), mockLogger, restTimeout)
 
 	// 存在しないPOSTルートへのリクエストを作成
 	req := httptest.NewRequest(http.MethodPost, "/api/unknown", nil)
@@ -112,6 +119,8 @@ func TestPostLogsRoute_NotFound(t *testing.T) {
 func TestGetLogsRoute_Success(t *testing.T) {
 	t.Parallel()
 
+	restTimeout := 3 * time.Second // テスト用の REST タイムアウト
+
 	// モックユースケースのGetLogsを成功レスポンスに設定
 	mockUC := new(appmock.LogUseCase)
 	mockUC.On("GetLogs",
@@ -123,7 +132,7 @@ func TestGetLogsRoute_Success(t *testing.T) {
 	).Return([]model.Log{}, nil)
 
 	mockLogger := appmock.NewLogger()
-	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger), mockLogger)
+	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger), mockLogger, restTimeout)
 
 	// GETリクエストを作成
 	req := httptest.NewRequest(http.MethodGet, "/api/logs?limit=100&offset=0&service=test-service&level=INFO", nil)
@@ -148,10 +157,12 @@ func TestGetLogsRoute_Success(t *testing.T) {
 func TestGetLogsRoute_NotFound(t *testing.T) {
 	t.Parallel()
 
+	restTimeout := 3 * time.Second // テスト用の REST タイムアウト
+
 	// モックのユースケースとロガーを準備
 	mockUC := new(appmock.LogUseCase)
 	mockLogger := appmock.NewLogger()
-	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger), mockLogger)
+	echoServer := server.NewRouter(rest.NewLogHandler(mockUC, mockLogger), mockLogger, restTimeout)
 
 	// 存在しないGETルートへのリクエストを作成
 	req := httptest.NewRequest(http.MethodGet, "/api/invalid", nil)


### PR DESCRIPTION
## 概要

`cmd/main.go` に機能を追加し、アプリ起動時に **gRPC / REST サーバー、PostgreSQL、NATS、Elasticsearch** を一括初期化するエントリーポイントを実装しました。Graceful shutdown と各サーバーのタイムアウト設定も追加しています。

## 主要な変更点 <!-- What was changed -->

| 種別         | ファイル / パッケージ | 変更内容                                                 |
| ------------ | --------------------- | -------------------------------------------------------- |
| **feat**     | `cmd/main.go`         | gRPC / REST 並列起動ロジックを実装                       |
| **feat**     | `internal/config`     | NATS・Elasticsearch URL、タイムアウト / ポート設定を追加 |
| **feat**     | `internal/logger`     | `ParseLevel` を追加し文字列指定を許可                    |
| **refactor** | `internal/pkg/server` | REST タイムアウトを引数で受け取るよう変更                |

## 動作確認手順 <!-- How to test -->

### 1. 必要な依存サービスを起動

```bash
# 必要な環境変数を .env に定義した上で実行
docker compose up --build db elasticsearch nats
```

### 2. アプリケーションを起動

```bash
go run cmd/main.go
```

起動に成功すると、以下のようなログが出力されることまで確認済み。

```text
{"time":"2025-06-05T03:22:43.733076+09:00","level":"INFO","msg":"Configuration loaded successfully", ... }
{"time":"2025-06-05T03:22:43.733334+09:00","level":"INFO","msg":"Database connection established"}
{"time":"2025-06-05T03:22:43.769333+09:00","level":"INFO","msg":"Connected to NATS successfully","url":"nats://localhost:4222"}
{"time":"2025-06-05T03:22:43.784751+09:00","level":"INFO","msg":"gRPC server started","address":"127.0.0.1:50051"}
{"time":"2025-06-05T03:22:43.786613+09:00","level":"INFO","msg":"Starting REST server","address":"0.0.0.0:8080"}
⇨ http server started on [::]:8080
```

細かい動作確認については、この後実装する統合テストで実施します。
