### PR TITLE
test: add integration tests

### DIFF
--- a/internal/testutil/helper/db_helper.go
+++ b/internal/testutil/helper/db_helper.go
@@ -1,0 +1,70 @@
+package testhelper
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3" // テスト用のインメモリDBで使用する SQLite ドライバ
+	"github.com/volatiletech/null/v8"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/infra/db/models"
+)
+
+// newTestBoilExecutor は、SQLite のインメモリ DB をセットアップし、テーブルスキーマを作成したうえで、
+// SQLBoiler 用の ContextExecutor と *sql.DB を返します。
+func newTestBoilExecutor() (*sql.DB, *sql.DB, error) {
+	// インメモリ DB に接続
+	dbConn, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open in-memory DB: %w", err)
+	}
+
+	// テーブルスキーマ定義
+	schema := `
+		CREATE TABLE logs (
+		id        TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+		trace_id  TEXT,
+		timestamp DATETIME NOT NULL,
+		level     TEXT NOT NULL CHECK (length(level) <= 10),
+		service   TEXT NOT NULL,
+		message   TEXT NOT NULL,
+		metadata  JSON
+		);
+	`
+
+	// スキーマを実行してテーブルを作成
+	if _, err := dbConn.Exec(schema); err != nil {
+		return nil, nil, fmt.Errorf("failed to create schema: %w", err)
+	}
+
+	// boil.ContextExecutor として dbConn を返却
+	return dbConn, dbConn, nil
+}
+
+// InsertTestLog は、テスト用のログレコードを 1 件生成し、
+// 指定された ContextExecutor で DB に挿入します。
+func InsertTestLog(ctx context.Context, exec boil.ContextExecutor) error {
+	//nolint:exhaustruct // LogL は型が生成されていないため初期化できない
+	log := &models.Log{
+		ID:        uuid.NewString(),                        // 一意のIDを生成
+		TraceID:   null.StringFrom("trace-123"),            // nullable 型
+		Timestamp: time.Now(),                              // 現在時刻を設定
+		Service:   "test-service",                          // サービス名
+		Level:     "INFO",                                  // ログレベル
+		Message:   "for test",                              // メッセージ内容
+		Metadata:  null.JSONFrom([]byte(`{"env":"test"}`)), // JSON メタデータ
+		R:         nil,                                     // 関連リレーションは省略
+		// L: models.LogL{}, ← 非公開型のため初期化を省略
+	}
+
+	// レコードを挿入
+	if err := log.Insert(ctx, exec, boil.Infer()); err != nil {
+		return fmt.Errorf("failed to insert test log: %w", err)
+	}
+
+	return nil
+}

--- a/internal/testutil/helper/grpc_helper.go
+++ b/internal/testutil/helper/grpc_helper.go
@@ -1,0 +1,120 @@
+package testhelper
+
+import (
+	"context"
+	"database/sql"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/test/bufconn"
+
+	grpcHandler "github.com/KeitaShimura/logs-collector-api/internal/app/handler/grpc"
+	grpcmw "github.com/KeitaShimura/logs-collector-api/internal/app/middleware/grpc"
+	"github.com/KeitaShimura/logs-collector-api/internal/app/usecase"
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+	appmock "github.com/KeitaShimura/logs-collector-api/internal/testutil/mock"
+	pb "github.com/KeitaShimura/logs-collector-protos/go/logs/v1"
+)
+
+// テスト用バッファサイズと gRPC タイムアウトを定義
+const (
+	bufSize     = 1024 * 1024
+	grpcTimeout = 2 * time.Second
+)
+
+// SetupGRPCTestHandler は、テスト用の gRPC クライアントを初期化し、
+// LogServiceClient、SQL DB、gRPC サーバ、モックプロデューサ・サーチャを返します。
+// closeDB が true の場合は、即時に DB 接続を閉じます。
+//
+//nolint:ireturn // gRPC クライアントの具体型は unexported なので、ireturn 警告は許容する
+func SetupGRPCTestHandler(
+	t *testing.T,
+	closeDB bool,
+) (
+	pb.LogServiceClient,
+	*sql.DB,
+	*grpc.Server,
+	*appmock.Producer,
+	*appmock.LogSearcher,
+) {
+	t.Helper()
+
+	// ユースケース層とモックを初期化
+	uc, sqlDB, mockProducer, mockSearcher := initTestUseCase(t)
+
+	// ロガーを生成
+	log := logger.NewLogger()
+	// gRPC サーバとバッファリスナを初期化
+	server, lis := initGRPCServer(uc, log)
+
+	// オプションで DB を即時クローズ
+	if closeDB {
+		sqlDB.Close()
+	}
+
+	// bufconn 用 Dialer を定義
+	bufDialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+
+	// gRPC クライアント接続を生成（passthrough:/// を利用）
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	// テスト終了時のクリーンアップ処理を登録
+	t.Cleanup(func() {
+		conn.Close()  // クライアント接続をクローズ
+		server.Stop() // gRPC サーバを停止
+
+		// closeDB が false の場合は DB をクローズ
+		if !closeDB {
+			sqlDB.Close()
+		}
+	})
+
+	// LogServiceClient インスタンスを生成
+	client := pb.NewLogServiceClient(conn)
+
+	return client, sqlDB, server, mockProducer, mockSearcher
+}
+
+// initGRPCServer は、bufconn リスナと gRPC サーバを初期化します。
+// 各種ミドルウェア（ロギング、タイムアウト、リカバリ、バリデーション）を設定して起動します。
+func initGRPCServer(logUseCase usecase.LogUseCase, log logger.Logger) (*grpc.Server, *bufconn.Listener) {
+	logHandler := grpcHandler.NewLogHandler(logUseCase, log)
+
+	// gRPC サーバを生成し、UnaryInterceptor チェーンを設定
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(
+			grpcmw.LoggingInterceptor(log),
+			grpcmw.TimeoutInterceptor(grpcTimeout, log),
+			grpcmw.RecoveryInterceptor(log),
+			grpcmw.ValidationInterceptor(log),
+		),
+	)
+
+	// LogServiceServer を登録
+	pb.RegisterLogServiceServer(grpcServer, logHandler)
+	reflection.Register(grpcServer)
+
+	// bufconn リスナを生成
+	listener := bufconn.Listen(bufSize)
+
+	// サーバを別ゴルーチンで起動
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil {
+			log.Error("gRPC server encountered an error", err)
+		}
+	}()
+
+	return grpcServer, listener
+}

--- a/internal/testutil/helper/init_helper.go
+++ b/internal/testutil/helper/init_helper.go
@@ -1,0 +1,40 @@
+package testhelper
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/usecase"
+	"github.com/KeitaShimura/logs-collector-api/internal/infra/db"
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+	appmock "github.com/KeitaShimura/logs-collector-api/internal/testutil/mock"
+)
+
+// initTestUseCase はユースケース層のテスト環境を初期化します。
+// 成功時には LogUseCaseImpl インスタンスとリソースを返却します。
+func initTestUseCase(t *testing.T) (*usecase.LogUseCaseImpl, *sql.DB, *appmock.Producer, *appmock.LogSearcher) {
+	t.Helper()
+
+	// テスト用のBoilエグゼキュータとSQL DBを初期化
+	exec, sqlDB, err := newTestBoilExecutor()
+	// 初期化に失敗したらテストを中断
+	require.NoError(t, err)
+
+	// ロガーを生成
+	log := logger.NewLogger()
+	// リポジトリにBoilエグゼキュータとロガーを注入
+	repo := db.NewLogRepository(exec, log)
+
+	// メッセージ送信用のモックProducerを生成
+	mockProducer := appmock.NewProducer()
+	// 検索用のモックSearcherを生成
+	mockSearcher := appmock.NewLogSearcher()
+
+	// ユースケース実装に依存性を注入して生成
+	uc := usecase.NewLogUseCase(repo, mockProducer, mockSearcher, log)
+
+	// ユースケース、DB、モックProducer/Searcherを返却
+	return uc, sqlDB, mockProducer, mockSearcher
+}

--- a/internal/testutil/helper/rest_helper.go
+++ b/internal/testutil/helper/rest_helper.go
@@ -1,0 +1,55 @@
+package testhelper
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	echoSwagger "github.com/swaggo/echo-swagger"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/app/handler/rest"
+	restmw "github.com/KeitaShimura/logs-collector-api/internal/app/middleware/rest"
+	"github.com/KeitaShimura/logs-collector-api/internal/logger"
+	"github.com/KeitaShimura/logs-collector-api/internal/pkg/validator"
+	appmock "github.com/KeitaShimura/logs-collector-api/internal/testutil/mock"
+)
+
+// テスト用の REST タイムアウトを定義
+const restTimeout = 3 * time.Second
+
+// SetupRestTestHandler は、REST API テスト用の環境を初期化し、
+// Echo サーバ、SQL DB、モックプロデューサ、モックサーチャを返します。
+func SetupRestTestHandler(t *testing.T) (*echo.Echo, *sql.DB, *appmock.Producer, *appmock.LogSearcher) {
+	t.Helper()
+
+	// ユースケースとモックを初期化
+	uc, sqlDB, mockProducer, mockSearcher := initTestUseCase(t)
+
+	// ロガーを生成し、ハンドラに注入
+	log := logger.NewLogger()
+	logHandler := rest.NewLogHandler(uc, log)
+
+	// Echo サーバインスタンスを生成
+	echoServer := echo.New()
+	// ミドルウェアを順次登録
+	echoServer.Use(restmw.LoggingMiddleware(log))              // ログ出力
+	echoServer.Use(restmw.TimeoutMiddleware(restTimeout, log)) // タイムアウト制御
+	echoServer.Use(restmw.RecoveryMiddleware(log))             // パニックリカバリ
+
+	// リクエストバリデーション設定
+	echoServer.Validator = validator.NewValidator()
+
+	// Swagger UI エンドポイントを登録
+	echoServer.GET("/swagger/*", echoSwagger.WrapHandler)
+
+	// API グループ
+	api := echoServer.Group("/api")
+
+	// API エンドポイントと対応ハンドラを登録
+	api.POST("/logs", logHandler.SendLog, restmw.ValidationMiddlewareSendLog(log))
+	api.GET("/logs", logHandler.GetLogs, restmw.ValidationMiddlewareGetLogs(log))
+
+	// 初期化したリソースを返却
+	return echoServer, sqlDB, mockProducer, mockSearcher
+}

--- a/tests/integration/grpc_getlogs_test.go
+++ b/tests/integration/grpc_getlogs_test.go
@@ -1,0 +1,134 @@
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/KeitaShimura/logs-collector-api/internal/testutil"
+	testhelper "github.com/KeitaShimura/logs-collector-api/internal/testutil/helper"
+	pb "github.com/KeitaShimura/logs-collector-protos/go/logs/v1"
+)
+
+// TestGRPC_GetLogs_Success は、正常系でログ取得が成功することを検証します。
+func TestGRPC_GetLogs_Success(t *testing.T) {
+	t.Parallel()
+
+	// gRPC クライアントと DB をセットアップ
+	client, db, _, _, _ := testhelper.SetupGRPCTestHandler(t, false) //nolint:dogsled // テスト対象は client のみのため未使用戻り値は破棄
+
+	// 事前に 1 件のテストログを挿入
+	require.NoError(t, testhelper.InsertTestLog(t.Context(), db))
+
+	// GetLogs RPC を呼び出し
+	resp, err := client.GetLogs(t.Context(), &pb.GetLogsRequest{
+		Service:   testutil.StringPtr("test-service"),
+		Level:     testutil.StringPtr("INFO"),
+		Limit:     10,
+		Offset:    0,
+		StartTime: nil,
+		EndTime:   nil,
+	})
+	// エラーなし、レスポンスが取得できていること
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.GreaterOrEqual(t, len(resp.GetLogs()), 1)
+}
+
+// TestGRPC_GetLogs_NotFound は、存在しない条件で NotFound エラーが返ることを検証します。
+func TestGRPC_GetLogs_NotFound(t *testing.T) {
+	t.Parallel()
+
+	// ログを挿入せずにクライアントのみセットアップ
+	client, _, _, _, _ := testhelper.SetupGRPCTestHandler(t, false) //nolint:dogsled // テスト対象は client のみのため未使用戻り値は破棄
+
+	// 存在しないサービス・レベルで呼び出し
+	resp, err := client.GetLogs(t.Context(), &pb.GetLogsRequest{
+		Service:   testutil.StringPtr("non-existent-service"),
+		Level:     testutil.StringPtr("DEBUG"),
+		Limit:     10,
+		Offset:    0,
+		StartTime: nil,
+		EndTime:   nil,
+	})
+	// エラーおよびステータスコード確認
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, st.Code())
+	// レスポンスは nil であること
+	require.Nil(t, resp)
+}
+
+// TestGRPC_GetLogs_DBConnectionFailure は、DB 接続障害時に Internal エラーとなることを検証します。
+func TestGRPC_GetLogs_DBConnectionFailure(t *testing.T) {
+	t.Parallel()
+
+	// closeDB=true に設定し、接続を即時クローズ
+	client, _, _, _, _ := testhelper.SetupGRPCTestHandler(t, true) //nolint:dogsled // テスト対象は client のみのため未使用戻り値は破棄
+
+	// RPC 呼び出し
+	_, err := client.GetLogs(t.Context(), &pb.GetLogsRequest{
+		Service:   testutil.StringPtr("test-service"),
+		Level:     testutil.StringPtr("INFO"),
+		Limit:     10,
+		Offset:    0,
+		StartTime: nil,
+		EndTime:   nil,
+	})
+	// Internal エラーを期待
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, st.Code())
+}
+
+// TestGRPC_GetLogs_EmptyQuery は、Level が nil (条件なし) の場合でも正常に取得できることを検証します。
+func TestGRPC_GetLogs_EmptyQuery(t *testing.T) {
+	t.Parallel()
+
+	client, db, _, _, _ := testhelper.SetupGRPCTestHandler(t, false) //nolint:dogsled // テスト対象は client のみのため未使用戻り値は破棄
+	// テストログを挿入
+	require.NoError(t, testhelper.InsertTestLog(t.Context(), db))
+
+	// Level を nil に設定
+	resp, err := client.GetLogs(t.Context(), &pb.GetLogsRequest{
+		Service:   testutil.StringPtr("test-service"),
+		Level:     nil, // レベル条件なし
+		Limit:     10,
+		Offset:    0,
+		StartTime: nil,
+		EndTime:   nil,
+	})
+	// 成功とログ件数の確認
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.GreaterOrEqual(t, len(resp.GetLogs()), 1)
+}
+
+// TestGRPC_GetLogs_OffsetTooLarge は、オフセットが範囲外の場合 NotFound エラーとなることを検証します。
+func TestGRPC_GetLogs_OffsetTooLarge(t *testing.T) {
+	t.Parallel()
+
+	client, db, _, _, _ := testhelper.SetupGRPCTestHandler(t, false) //nolint:dogsled // テスト対象は client のみのため未使用戻り値は破棄
+	// テストログを挿入
+	require.NoError(t, testhelper.InsertTestLog(t.Context(), db))
+
+	// 存在しない大きなオフセットを指定
+	resp, err := client.GetLogs(t.Context(), &pb.GetLogsRequest{
+		Service:   testutil.StringPtr("test-service"),
+		Level:     testutil.StringPtr("INFO"),
+		Limit:     10,
+		Offset:    9999, // 存在しないオフセット
+		StartTime: nil,
+		EndTime:   nil,
+	})
+	// NotFound エラーを期待
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, st.Code())
+	require.Nil(t, resp)
+}

--- a/tests/integration/grpc_sendlog_test.go
+++ b/tests/integration/grpc_sendlog_test.go
@@ -1,0 +1,191 @@
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	testhelper "github.com/KeitaShimura/logs-collector-api/internal/testutil/helper"
+	pb "github.com/KeitaShimura/logs-collector-protos/go/logs/v1"
+)
+
+// TestGRPC_SendLog は、SendLog RPC の正常系を検証します。
+func TestGRPC_SendLog(t *testing.T) {
+	t.Parallel()
+
+	// gRPC クライアント、モックProducer/Searcherをセットアップ（DBはクローズしない）
+	client, _, _, mockProducer, mockSearcher := testhelper.SetupGRPCTestHandler(t, false)
+
+	// テスト用リクエスト生成
+	req := &pb.SendLogRequest{
+		Log: &pb.Log{
+			Id:        uuid.NewString(),
+			Service:   "test-service",
+			Level:     "INFO",
+			Message:   "integration test log",
+			TraceId:   "trace-123",
+			Timestamp: timestamppb.Now(),
+			Metadata:  map[string]string{"env": "test"},
+		},
+	}
+
+	// RPC 呼び出しとレスポンス検証
+	resp, err := client.SendLog(t.Context(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.True(t, resp.GetSuccess())
+
+	// モックNATSへのパブリッシュ検証
+	require.Len(t, mockProducer.PublishedMessages, 1)
+	published := mockProducer.PublishedMessages[0]
+	require.Equal(t, req.GetLog().GetId(), published.ID)
+
+	// モックElasticsearch検索呼び出し検証
+	require.Len(t, mockSearcher.Calls, 1)
+	require.Equal(t, "logs-index", mockSearcher.Calls[0].Index)
+	require.Contains(t, mockSearcher.Calls[0].LogData["message"], "integration test log")
+}
+
+// TestGRPC_SendLog_DuplicateID は、重複IDによるエラーを検証します。
+func TestGRPC_SendLog_DuplicateID(t *testing.T) {
+	t.Parallel()
+
+	client, _, _, mockProducer, mockSearcher := testhelper.SetupGRPCTestHandler(t, false)
+
+	// 同一IDで2回リクエストを投げる
+	req := &pb.SendLogRequest{
+		Log: &pb.Log{
+			Id:        uuid.NewString(),
+			Service:   "test-service",
+			Level:     "INFO",
+			Message:   "first message",
+			TraceId:   "trace-123",
+			Timestamp: timestamppb.Now(),
+			Metadata:  map[string]string{},
+		},
+	}
+
+	// 1回目は成功
+	resp, err := client.SendLog(t.Context(), req)
+	require.NoError(t, err)
+	require.True(t, resp.GetSuccess())
+
+	// 2回目は重複エラー
+	_, err = client.SendLog(t.Context(), req)
+	require.Error(t, err)
+
+	// モック呼び出し回数は1回のみであることを確認
+	// モックNATSへのパブリッシュ検証
+	require.Len(t, mockProducer.PublishedMessages, 1)
+	published := mockProducer.PublishedMessages[0]
+	require.Equal(t, req.GetLog().GetId(), published.ID)
+
+	// モックElasticsearch検索呼び出し検証
+	require.Len(t, mockSearcher.Calls, 1)
+	require.Equal(t, "logs-index", mockSearcher.Calls[0].Index)
+	require.Contains(t, mockSearcher.Calls[0].LogData["message"], "first message")
+}
+
+// TestGRPC_SendLog_DBConnectionFailure は、DB接続障害時に Internal エラーとなることを検証します。
+func TestGRPC_SendLog_DBConnectionFailure(t *testing.T) {
+	t.Parallel()
+
+	// DBを即時クローズしてセットアップ
+	client, _, _, mockProducer, mockSearcher := testhelper.SetupGRPCTestHandler(t, true)
+
+	// リクエスト生成
+	req := &pb.SendLogRequest{
+		Log: &pb.Log{
+			Id:        uuid.NewString(),
+			Service:   "test-service",
+			Level:     "INFO",
+			Message:   "should fail",
+			TraceId:   "trace-err",
+			Timestamp: timestamppb.Now(),
+			Metadata:  map[string]string{"env": "test"},
+		},
+	}
+
+	// RPC 呼び出し
+	resp, err := client.SendLog(t.Context(), req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Internal, st.Code())
+	require.Nil(t, resp)
+
+	// モック呼び出しは行われていないことを確認
+	require.Empty(t, mockProducer.PublishedMessages)
+	require.Empty(t, mockSearcher.Calls)
+}
+
+// TestGRPC_SendLog_MissingService は、Service 欄が空の場合に InvalidArgument エラーとなることを検証します。
+func TestGRPC_SendLog_MissingService(t *testing.T) {
+	t.Parallel()
+
+	client, _, _, mockProducer, mockSearcher := testhelper.SetupGRPCTestHandler(t, false)
+
+	// Service が空文字のリクエスト
+	req := &pb.SendLogRequest{
+		Log: &pb.Log{
+			Id:        uuid.NewString(),
+			Service:   "", // Service 未指定
+			Level:     "INFO",
+			Message:   "missing service",
+			TraceId:   "trace-123",
+			Timestamp: timestamppb.Now(),
+			Metadata:  map[string]string{},
+		},
+	}
+
+	// RPC 呼び出し
+	resp, err := client.SendLog(t.Context(), req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
+	require.Nil(t, resp)
+
+	// モック呼び出しは行われていないことを確認
+	require.Empty(t, mockProducer.PublishedMessages)
+	require.Empty(t, mockSearcher.Calls)
+}
+
+// TestGRPC_SendLog_MetadataNil は、Metadata が nil の場合でも正常に動作することを検証します。
+func TestGRPC_SendLog_MetadataNil(t *testing.T) {
+	t.Parallel()
+
+	client, _, _, mockProducer, mockSearcher := testhelper.SetupGRPCTestHandler(t, false)
+
+	// Metadata を nil に設定したリクエスト
+	req := &pb.SendLogRequest{
+		Log: &pb.Log{
+			Id:        uuid.NewString(),
+			Service:   "test-service",
+			Level:     "INFO",
+			Message:   "metadata is nil",
+			TraceId:   "trace-xyz",
+			Timestamp: timestamppb.Now(),
+			Metadata:  nil,
+		},
+	}
+
+	// RPC 呼び出しと結果検証
+	resp, err := client.SendLog(t.Context(), req)
+	require.NoError(t, err)
+	require.True(t, resp.GetSuccess())
+
+	// モックNATSへのパブリッシュ検証
+	require.Len(t, mockProducer.PublishedMessages, 1)
+	published := mockProducer.PublishedMessages[0]
+	require.Equal(t, req.GetLog().GetId(), published.ID)
+
+	// モックElasticsearch検索呼び出し検証
+	require.Len(t, mockSearcher.Calls, 1)
+	require.Equal(t, "logs-index", mockSearcher.Calls[0].Index)
+	require.Contains(t, mockSearcher.Calls[0].LogData["message"], "metadata is nil")
+}

--- a/tests/integration/rest_getlogs_test.go
+++ b/tests/integration/rest_getlogs_test.go
@@ -1,0 +1,111 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	testhelper "github.com/KeitaShimura/logs-collector-api/internal/testutil/helper"
+)
+
+// TestGetLogs_Success は、REST API の /logs エンドポイントで、正常にログ一覧が返却されることを検証します。
+func TestGetLogs_Success(t *testing.T) {
+	t.Parallel()
+
+	// Echo サーバと DB、モックをセットアップ
+	echoServer, sqlDB, _, _ := testhelper.SetupRestTestHandler(t)
+	defer sqlDB.Close() // テスト終了後に DB 接続をクローズ
+
+	// テスト用データを事前に挿入
+	require.NoError(t, testhelper.InsertTestLog(t.Context(), sqlDB))
+
+	// HTTP リクエストを作成（クエリパラメータ付き）
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?service=test-service&level=INFO&limit=10&offset=0", nil)
+	rec := httptest.NewRecorder()
+	// サーバにリクエストを送信
+	echoServer.ServeHTTP(rec, req)
+
+	// レスポンスボディを JSON としてパース
+	var logs []map[string]interface{}
+	err := json.Unmarshal(rec.Body.Bytes(), &logs)
+	require.NoError(t, err)
+
+	// 期待通り 1 件のログが返却され、Service フィールドが一致すること
+	require.Len(t, logs, 1)
+	require.Equal(t, "test-service", logs[0]["Service"])
+}
+
+// TestGetLogs_EmptyResult は、該当ログが存在しない場合に、HTTP 404 が返却されることを検証します。
+func TestGetLogs_EmptyResult(t *testing.T) {
+	t.Parallel()
+
+	echoServer, sqlDB, _, _ := testhelper.SetupRestTestHandler(t)
+	defer sqlDB.Close()
+
+	// ログを挿入せずに GET リクエスト
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?service=not-found&level=DEBUG&limit=10&offset=0", nil)
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// ステータスコードが 404 Not Found であること
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestGetLogs_InvalidQueryParam は、クエリパラメータが不正な場合に、HTTP 400 が返却されることを検証します。
+func TestGetLogs_InvalidQueryParam(t *testing.T) {
+	t.Parallel()
+
+	echoServer, sqlDB, _, _ := testhelper.SetupRestTestHandler(t)
+	defer sqlDB.Close()
+
+	// limit に文字列を指定して不正リクエストを作成
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?limit=abc", nil)
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// ステータスコードが 400 Bad Request であること
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestGetLogs_DBFailure は、DB 接続障害時に、HTTP 500 が返却されることを検証します。
+func TestGetLogs_DBFailure(t *testing.T) {
+	t.Parallel()
+
+	echoServer, sqlDB, _, _ := testhelper.SetupRestTestHandler(t)
+	// 意図的に DB 接続をクローズして障害を発生
+	sqlDB.Close()
+
+	// サービスとレベルのみ指定してリクエスト
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?service=test-service&level=INFO", nil)
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// ステータスコードが 500 Internal Server Error であること
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// TestGetLogs_OnlyServiceQuery は、service のみ指定した場合でも、正常にログが返却されることを検証します。
+func TestGetLogs_OnlyServiceQuery(t *testing.T) {
+	t.Parallel()
+
+	echoServer, sqlDB, _, _ := testhelper.SetupRestTestHandler(t)
+	defer sqlDB.Close()
+
+	// テストログを事前に挿入
+	require.NoError(t, testhelper.InsertTestLog(t.Context(), sqlDB))
+
+	// service パラメータのみ指定してリクエスト
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?service=test-service", nil)
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// レスポンスをパースし、1 件のログが返却されることを検証
+	var logs []map[string]interface{}
+	err := json.Unmarshal(rec.Body.Bytes(), &logs)
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	require.Equal(t, "test-service", logs[0]["Service"])
+}

--- a/tests/integration/rest_sendlog_test.go
+++ b/tests/integration/rest_sendlog_test.go
@@ -1,0 +1,181 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
+	testhelper "github.com/KeitaShimura/logs-collector-api/internal/testutil/helper"
+)
+
+// REST POST /api/logs の統合テスト
+
+// TestPostLogs_ValidRequest は、正しいログ送信リクエストを送った場合のフローを検証します。
+//  1. HTTP 200 を返す
+//  2. NATS / Elasticsearch のモックが 1 回ずつ呼ばれる
+func TestPostLogs_ValidRequest(t *testing.T) {
+	t.Parallel()
+
+	// 前処理: Echo サーバーとモックを初期化
+	echoServer, sqlDB, mockProducer, mockSearcher := testhelper.SetupRestTestHandler(t)
+	defer sqlDB.Close()
+
+	// 入力データ生成
+	body := `{
+        "log": {
+            "trace_id": "trace-123",
+            "timestamp": "` + time.Now().UTC().Format(time.RFC3339) + `",
+            "level": "INFO",
+            "service": "test-service",
+            "message": "integration test log",
+            "metadata": {"env": "test"}
+        }
+    }`
+
+	// HTTP リクエスト送信
+	req := httptest.NewRequest(http.MethodPost, "/api/logs", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// 検証
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, mockProducer.PublishedMessages, 1)
+	require.Len(t, mockSearcher.Calls, 1)
+}
+
+// TestPostLogs_EmptyService は service が空の場合を検証します。
+//   - 期待: HTTP 400, NATS / Elasticsearch のモック呼び出し 0 回
+func TestPostLogs_EmptyService(t *testing.T) {
+	t.Parallel()
+
+	// 前処理
+	echoServer, sqlDB, mockProducer, mockSearcher := testhelper.SetupRestTestHandler(t)
+	defer sqlDB.Close()
+
+	// 入力データ（service が空）
+	body := `{
+        "log": {
+            "trace_id": "trace-123",
+            "timestamp": "` + time.Now().UTC().Format(time.RFC3339) + `",
+            "level": "INFO",
+            "service": "",
+            "message": "no service",
+            "metadata": {}
+        }
+    }`
+
+	// リクエスト送信
+	req := httptest.NewRequest(http.MethodPost, "/api/logs", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// 検証
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Empty(t, mockProducer.PublishedMessages)
+	require.Empty(t, mockSearcher.Calls)
+}
+
+// TestPostLogs_InvalidJSON は JSON が壊れている場合を検証します。
+//   - 期待: HTTP 400, NATS / Elasticsearch のモック呼び出し 0 回
+func TestPostLogs_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	// 前処理
+	echoServer, sqlDB, mockProducer, mockSearcher := testhelper.SetupRestTestHandler(t)
+	defer sqlDB.Close()
+
+	// 不正な JSON
+	body := `{"log": {"trace_id": "abc", "timestamp": "bad"}`
+
+	// リクエスト送信
+	req := httptest.NewRequest(http.MethodPost, "/api/logs", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// 検証
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Empty(t, mockProducer.PublishedMessages)
+	require.Empty(t, mockSearcher.Calls)
+}
+
+// TestPostLogs_FutureTimestamp は timestamp が将来日付の場合を検証します。
+//   - 期待: HTTP 400, NATS / Elasticsearch のモック呼び出し 0 回
+func TestPostLogs_FutureTimestamp(t *testing.T) {
+	t.Parallel()
+
+	// 前処理
+	echoServer, sqlDB, mockProducer, mockSearcher := testhelper.SetupRestTestHandler(t)
+	defer sqlDB.Close()
+
+	// 未来日時を設定
+	future := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	body := `{
+        "log": {
+            "trace_id": "trace-123",
+            "timestamp": "` + future + `",
+            "level": "INFO",
+            "service": "test-service",
+            "message": "future timestamp",
+            "metadata": {}
+        }
+    }`
+
+	// リクエスト送信
+	req := httptest.NewRequest(http.MethodPost, "/api/logs", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// 検証
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Empty(t, mockProducer.PublishedMessages)
+	require.Empty(t, mockSearcher.Calls)
+}
+
+// TestPostLogs_DBFailure は DB 接続エラー時を検証します。
+//   - 期待: HTTP 500, NATS / Elasticsearch のモック呼び出し 0 回
+func TestPostLogs_DBFailure(t *testing.T) {
+	t.Parallel()
+
+	// 前処理
+	echoServer, sqlDB, mockProducer, mockSearcher := testhelper.SetupRestTestHandler(t)
+
+	// DB を故意に閉じる
+	sqlDB.Close()
+
+	// 入力データ
+	body := `{
+        "log": {
+            "trace_id": "trace-err",
+            "timestamp": "` + time.Now().UTC().Format(time.RFC3339) + `",
+            "level": "INFO",
+            "service": "test-service",
+            "message": "should fail",
+            "metadata": {}
+        }
+    }`
+
+	// リクエスト送信
+	req := httptest.NewRequest(http.MethodPost, "/api/logs", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+
+	rec := httptest.NewRecorder()
+	echoServer.ServeHTTP(rec, req)
+
+	// 検証
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Empty(t, mockProducer.PublishedMessages)
+	require.Empty(t, mockSearcher.Calls)
+}


### PR DESCRIPTION
## 概要

gRPC と REST の **両方の API** に対して統合テストを追加しました。

> アプリを「ハンドラ ➜ ユースケース ➜ リポジトリ ➜ DB」まで実際につないで動かすテスト

インメモリ **SQLite** を使った軽量データベースと、ハンドラ／サーバを一括で立ち上げるテスト用ヘルパーを用意し、  
外部サービス（PostgreSQL・NATS・Elasticsearch）を起動せずに **SendLog / GetLogs** の正常系・異常系をまとめてチェックできるようになりました。

## 主要な変更点 <!-- What was changed -->

| 種別     | ファイル / パッケージ                     | 変更内容                                                          |
| -------- | ----------------------------------------- | ----------------------------------------------------------------- |
| **test** | `internal/testutil/helper/db_helper.go`   | インメモリ SQLite DB とテーブル生成ヘルパを追加                   |
| **test** | `internal/testutil/helper/init_helper.go` | ユースケースとモックをまとめて初期化する共通関数を追加            |
| **test** | `internal/testutil/helper/rest_helper.go` | Echo + ミドルウェア込みの REST テストサーバを起動するヘルパを追加 |
| **test** | `internal/testutil/helper/grpc_helper.go` | `bufconn` を使った gRPC テストサーバを起動するヘルパを追加        |
| **test** | `tests/integration/grpc_sendlog_test.go`  | gRPC **SendLog** の統合テスト                                     |
| **test** | `tests/integration/grpc_getlogs_test.go`  | gRPC **GetLogs** の統合テスト                                     |
| **test** | `tests/integration/rest_sendlog_test.go`  | REST `POST /api/logs` の統合テスト                                |
| **test** | `tests/integration/rest_getlogs_test.go`  | REST `GET /api/logs` の統合テスト                                 |

## 動作確認手順 <!-- How to test -->

1. **統合テストを実行**

   ```bash
   # データレース検知 (-race) も有効にして実行
   go test -v -race -cover ./tests/integration/...
   ```

2. すべてのテストが **PASS** と表示されれば OK です。  
   インメモリ DB とモック（NATS / Elasticsearch）を使っているため、  
   Docker などで外部サービスを起動する必要はありません。
